### PR TITLE
🐛 Correct properties for attachment model

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@unocha/hpc-api-core",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Core libraries supporting HPC.Tools API Backend",
   "license": "Apache-2.0",
   "private": false,

--- a/src/db/models/attachment.ts
+++ b/src/db/models/attachment.ts
@@ -17,10 +17,6 @@ export type AttachmentId = Brand<
 
 export const ATTACHMENT_ID = brandedType<number, AttachmentId>(t.number);
 
-export const COST_ATTACHMENT_VALUE = t.type({
-  cost: t.number,
-});
-
 export const ATTACHMENT_OBJECT_TYPE = t.keyof({
   governingEntity: null,
   plan: null,

--- a/src/db/models/attachment.ts
+++ b/src/db/models/attachment.ts
@@ -3,7 +3,10 @@ import { brandedType } from '../../util/io-ts';
 
 import type { Brand } from '../../util/types';
 import { defineLegacyVersionedModel } from '../util/legacy-versioned-model';
-import { ATTACHMENT_PROTOTYPE_ID } from './attachmentPrototype';
+import {
+  ATTACHMENT_PROTOTYPE_ID,
+  ATTACHMENT_TYPE,
+} from './attachmentPrototype';
 import { PLAN_ID } from './plan';
 
 export type AttachmentId = Brand<
@@ -16,6 +19,12 @@ export const ATTACHMENT_ID = brandedType<number, AttachmentId>(t.number);
 
 export const COST_ATTACHMENT_VALUE = t.type({
   cost: t.number,
+});
+
+export const ATTACHMENT_OBJECT_TYPE = t.keyof({
+  governingEntity: null,
+  plan: null,
+  planEntity: null,
 });
 
 export default defineLegacyVersionedModel({
@@ -44,11 +53,11 @@ export default defineLegacyVersionedModel({
       },
       objectType: {
         kind: 'checked',
-        type: t.string,
+        type: ATTACHMENT_OBJECT_TYPE,
       },
       type: {
         kind: 'checked',
-        type: t.string,
+        type: ATTACHMENT_TYPE,
       },
     },
   },

--- a/src/db/models/planVersion.ts
+++ b/src/db/models/planVersion.ts
@@ -44,7 +44,6 @@ export default defineLegacyVersionedModel({
         brand: PLAN_REPORTING_PERIOD_ID,
       },
       lastPublishedReportingPeriodId: { kind: 'checked', type: t.number },
-      // Even though this column isn't defined using DB enum only two values are used
       clusterSelectionType: {
         kind: 'checked',
         type: PLAN_VERSION_CLUSTER_SELECTION_TYPE,


### PR DESCRIPTION
Stricter types can be used for objectType and type, which was the case
for the old attachment model, so we should continue that here.