### PR TITLE
♻️ Move HPC-8205 functions into hpc-api-core

### DIFF
--- a/src/lib/context.ts
+++ b/src/lib/context.ts
@@ -1,8 +1,6 @@
-import v4Models from '../db';
+import { Database } from '../db/type';
 import { Config } from '../lib/config';
 import { SharedLogContext, SharedLogData } from '../lib/logging';
-
-type Models = ReturnType<typeof v4Models>;
 
 /**
  * An object that encapsulates all the context that may need to be passed to
@@ -12,7 +10,7 @@ type Models = ReturnType<typeof v4Models>;
  */
 export class Context {
   public readonly config: Config;
-  public readonly models: Models;
+  public readonly models: Database;
   public readonly token: string | null;
   public readonly log: SharedLogContext;
 
@@ -23,7 +21,7 @@ export class Context {
     log,
   }: {
     config: Config;
-    models: Models;
+    models: Database;
     token: string | null;
     log: SharedLogContext;
   }) {

--- a/src/lib/data/attachments.ts
+++ b/src/lib/data/attachments.ts
@@ -175,7 +175,9 @@ export const getAllAttachments = async ({
       const parentEntity = planEntities.get(parent.id);
       /* istanbul ignore if - this should not happen as it should already be validated in computePlanAttachmentParent */
       if (!parentEntity) {
-        throw new Error(`Unexpected error`);
+        throw new Error(
+          `Internal data inconsistency found for planEntity ${parent.id}`
+        );
       }
       if (parentEntity.governingEntity) {
         governingEntity = parentEntity.governingEntity;
@@ -232,22 +234,24 @@ const computeAttachmentParent = ({
 }): AttachmentParent => {
   if (attachment.objectType === 'plan') {
     return { type: 'plan' };
-  }
-  if (attachment.objectType === 'governingEntity') {
+  } else if (attachment.objectType === 'governingEntity') {
     const ge = governingEntities.get(createBrandedValue(attachment.objectId));
     if (!ge) {
-      throw new Error(`Invalid objectType for attachment ${attachment.id}`);
+      throw new Error(
+        `Couldn't find governingEntity for attachment ${attachment.id}`
+      );
     }
     return { type: 'governingEntity', id: ge.governingEntity.id };
-  }
-  if (attachment.objectType === 'planEntity') {
+  } else if (attachment.objectType === 'planEntity') {
     const e = planEntities.get(createBrandedValue(attachment.objectId));
     if (!e) {
-      throw new Error(`Invalid objectType for attachment ${attachment.id}`);
+      throw new Error(
+        `Couldn't find planEntity for attachment ${attachment.id}`
+      );
     }
     return { type: 'planEntity', id: e.id };
   }
-  throw new Error('Unknown attachment parent type');
+  throw new Error(`Invalid objectType for attachment ${attachment.id}`);
 };
 
 /**

--- a/src/lib/data/attachments.ts
+++ b/src/lib/data/attachments.ts
@@ -1,0 +1,343 @@
+import { isLeft } from 'fp-ts/lib/Either';
+import * as t from 'io-ts';
+import { AttachmentId } from '../../db/models/attachment';
+import {
+  AttachmentPrototypeId,
+  AttachmentType,
+} from '../../db/models/attachmentPrototype';
+import { GoverningEntityId } from '../../db/models/governingEntity';
+import { ATTACHMENT_VERSION_VALUE } from '../../db/models/json/attachment';
+import { PlanId } from '../../db/models/plan';
+import { PlanEntityId } from '../../db/models/planEntity';
+import { Database } from '../../db/type';
+import { InstanceDataOfModel } from '../../db/util/raw-model';
+import { organizeObjectsByUniqueProperty } from '../../util';
+import { ioTsErrorFormatter } from '../../util/io-ts';
+import { createBrandedValue } from '../../util/types';
+import { SharedLogContext } from '../logging';
+import { MapOfGoverningEntities } from './governingEntities';
+import {
+  calculateReflectiveTransitiveEntitySupport,
+  ValidatedPlanEntities,
+} from './planEntities';
+
+const ATTACHMENT_DATA = t.union([
+  t.type({
+    type: t.literal('caseLoad'),
+    value: ATTACHMENT_VERSION_VALUE['caseLoad'],
+  }),
+  t.type({
+    type: t.literal('contact'),
+    value: ATTACHMENT_VERSION_VALUE['contact'],
+  }),
+  t.type({
+    type: t.literal('cost'),
+    value: ATTACHMENT_VERSION_VALUE['cost'],
+  }),
+  t.type({
+    type: t.literal('fileWebContent'),
+    value: ATTACHMENT_VERSION_VALUE['fileWebContent'],
+  }),
+  t.type({
+    type: t.literal('indicator'),
+    value: ATTACHMENT_VERSION_VALUE['indicator'],
+  }),
+  t.type({
+    type: t.literal('textWebContent'),
+    value: ATTACHMENT_VERSION_VALUE['textWebContent'],
+  }),
+]);
+
+type AttachmentData = t.TypeOf<typeof ATTACHMENT_DATA>;
+
+type AttachmentParent =
+  | { type: 'plan' }
+  | { type: 'governingEntity'; id: GoverningEntityId }
+  | { type: 'planEntity'; id: PlanEntityId };
+
+export type AttachmentResult = {
+  id: AttachmentId;
+  customRef: string;
+  /**
+   * The part of the plan under which this attachment is directly nested
+   */
+  parent: AttachmentParent;
+  /**
+   * If set, this particular plan attachment is associated with the given
+   * governing entity. This does not necessarily mean that data available
+   * in `parent` is duplicated, because if `type` is `'planEntity'`,
+   * this field can be populated via parent of a plan entity
+   */
+  governingEntity: GoverningEntityId | null;
+  /**
+   * List of all plan entities that this attachment is associated with,
+   * along with any entities that are transitively supported
+   */
+  supportsEntities: PlanEntityId[];
+  /**
+   * The attachment type, along with the type-checked data from its value
+   */
+  data: AttachmentData;
+};
+
+type AttachmentResults = Map<AttachmentId, AttachmentResult>;
+
+/**
+ * Get all of the attachments of a particular type for a particular plan.
+ *
+ * In addition to fetching the attachments, this also validates the contents of
+ * their value field, ensuring they are of the correct type.
+ */
+export const getAllAttachments = async ({
+  database,
+  planId,
+  types,
+  planEntities,
+  governingEntities,
+  log,
+}: {
+  database: Database;
+  planId: PlanId;
+  types: AttachmentType[];
+  version: 'latest';
+  /**
+   * A map of plan entities, which **must** include any entity that is the
+   * parent of the given attachment.
+   *
+   * Usually all the entities for a given plan are provided
+   */
+  planEntities: ValidatedPlanEntities;
+  /**
+   * A map of governing entities, which **must** include any governing entity
+   * that is the parent of the given attachment.
+   *
+   * Usually all the governing entities for a given plan are provided
+   */
+  governingEntities: MapOfGoverningEntities;
+  log: SharedLogContext;
+}): Promise<AttachmentResults> => {
+  const prototypes = await database.attachmentPrototype.find({
+    where: (builder) =>
+      builder.whereIn('type', types).andWhere('planId', planId),
+  });
+  const attachmentPrototypesById = organizeObjectsByUniqueProperty(
+    prototypes,
+    'id'
+  );
+
+  const planAttachments = await database.attachment.find({
+    where: (builder) =>
+      builder.whereIn('type', types).andWhere('planId', planId),
+  });
+  const planAttachmentVersions = await database.attachmentVersion.find({
+    where: (builder) =>
+      builder
+        .whereIn(
+          'attachmentId',
+          planAttachments.map((pa) => pa.id)
+        )
+        .andWhere('latestVersion', true),
+  });
+  const planAttachmentVersionsByAttachmentId = organizeObjectsByUniqueProperty(
+    planAttachmentVersions,
+    'attachmentId'
+  );
+  const result: AttachmentResults = new Map();
+
+  for (const attachment of planAttachments) {
+    const attachmentVersion = planAttachmentVersionsByAttachmentId.get(
+      attachment.id
+    );
+    if (!attachmentVersion) {
+      throw new Error(
+        `Missing attachment version for attachment ${attachment.id}`
+      );
+    }
+    const customRef = composeCustomReferenceForAttachment({
+      attachment,
+      attachmentVersion,
+      attachmentPrototypes: attachmentPrototypesById,
+      planEntities,
+      governingEntities,
+    });
+    const parent = computeAttachmentParent({
+      attachment,
+      governingEntities,
+      planEntities,
+    });
+
+    // Calculate governingEntity and supportsEntities
+    let governingEntity: GoverningEntityId | null = null;
+    const supportsEntities: PlanEntityId[] = [];
+    if (parent.type === 'governingEntity') {
+      governingEntity = parent.id;
+    } else if (parent.type === 'planEntity') {
+      const parentEntity = planEntities.get(parent.id);
+      /* istanbul ignore if - this should not happen as it should already be validated in computePlanAttachmentParent */
+      if (!parentEntity) {
+        throw new Error(`Unexpected error`);
+      }
+      if (parentEntity.governingEntity) {
+        governingEntity = parentEntity.governingEntity;
+      }
+      supportsEntities.push(
+        ...calculateReflectiveTransitiveEntitySupport({
+          planEntities,
+          planEntity: parentEntity,
+        })
+      );
+    }
+    const data = typeCheckAttachmentData({
+      attachment,
+      attachmentVersion,
+      log,
+    });
+    result.set(attachment.id, {
+      id: attachment.id,
+      customRef,
+      parent,
+      governingEntity,
+      supportsEntities,
+      data,
+    });
+  }
+
+  return result;
+};
+
+/**
+ * Calculate a type-safe representation of the parent of an attachment,
+ * and also validate the ID against a map of allowed entities.
+ */
+const computeAttachmentParent = ({
+  attachment,
+  planEntities,
+  governingEntities,
+}: {
+  attachment: InstanceDataOfModel<Database['attachment']>;
+  /**
+   * A map of plan entities, which **must** include any entity that is the
+   * parent of the given attachment.
+   *
+   * Usually all the entities for a given plan are provided
+   */
+  planEntities: ValidatedPlanEntities;
+  /**
+   * A map of governing entities, which **must** include any governing entity
+   * that is the parent of the given attachment.
+   *
+   * Usually all the governing entities for a given plan are provided
+   */
+  governingEntities: MapOfGoverningEntities;
+}): AttachmentParent => {
+  if (attachment.objectType === 'plan') {
+    return { type: 'plan' };
+  }
+  if (attachment.objectType === 'governingEntity') {
+    const ge = governingEntities.get(createBrandedValue(attachment.objectId));
+    if (!ge) {
+      throw new Error(`Invalid objectType for attachment ${attachment.id}`);
+    }
+    return { type: 'governingEntity', id: ge.governingEntity.id };
+  }
+  if (attachment.objectType === 'planEntity') {
+    const e = planEntities.get(createBrandedValue(attachment.objectId));
+    if (!e) {
+      throw new Error(`Invalid objectType for attachment ${attachment.id}`);
+    }
+    return { type: 'planEntity', id: e.id };
+  }
+  throw new Error('Unknown attachment parent type');
+};
+
+/**
+ * Type-Check the given attachment's value against its type, and return both the
+ * type and the value in a type-safe manner.
+ */
+export const typeCheckAttachmentData = ({
+  attachment,
+  attachmentVersion,
+  log,
+}: {
+  attachment: InstanceDataOfModel<Database['attachment']>;
+  attachmentVersion: InstanceDataOfModel<Database['attachmentVersion']>;
+  log: SharedLogContext;
+}): AttachmentData => {
+  const result = {
+    type: attachment.type,
+    value: attachmentVersion.value,
+  };
+  const decodedValue = ATTACHMENT_DATA.decode(result);
+  if (isLeft(decodedValue)) {
+    const report = ioTsErrorFormatter(decodedValue);
+    for (const err of report) {
+      log.info(err);
+    }
+    throw new Error(`Invalid attachment value for ${attachment.id}`);
+  }
+  return decodedValue.right;
+};
+
+export const composeCustomReferenceForAttachment = ({
+  attachment,
+  attachmentVersion,
+  attachmentPrototypes,
+  planEntities,
+  governingEntities,
+}: {
+  attachment: InstanceDataOfModel<Database['attachment']>;
+  attachmentVersion: InstanceDataOfModel<Database['attachmentVersion']>;
+  /**
+   * A map of attachment prototypes, which **must** include the prototype for
+   * the given attachment.
+   *
+   * Usually all the prototypes for a given plan are provided
+   */
+  attachmentPrototypes: Map<
+    AttachmentPrototypeId,
+    InstanceDataOfModel<Database['attachmentPrototype']>
+  >;
+  /**
+   * A map of plan entities, which **must** include any entity that is the
+   * parent of the given attachment.
+   *
+   * Usually all the entities for a given plan are provided
+   */
+  planEntities: ValidatedPlanEntities;
+  /**
+   * A map of governing entities, which **must** include any governing entity
+   * that is the parent of the given attachment.
+   *
+   * Usually all the governing entities for a given plan are provided
+   */
+  governingEntities: MapOfGoverningEntities;
+}): string => {
+  if (!attachment.attachmentPrototypeId) {
+    throw new Error(
+      `Missing attachmentPrototypeId for attachment ${attachment.id}`
+    );
+  }
+  const prototype = attachmentPrototypes.get(attachment.attachmentPrototypeId);
+  if (!prototype) {
+    throw new Error(`Missing prototype for attachment ${attachment.id}`);
+  }
+
+  let customReference = '';
+  if (attachment.objectType === 'planEntity') {
+    const entity = planEntities.get(createBrandedValue(attachment.objectId));
+    if (!entity) {
+      throw new Error(`Missing parent entity for attachment ${attachment.id}`);
+    }
+    customReference = `${entity.customRef}/`;
+  } else if (attachment.objectType === 'governingEntity') {
+    const ge = governingEntities.get(createBrandedValue(attachment.objectId));
+    if (!ge) {
+      throw new Error(
+        `Missing parent governing entity for attachment ${attachment.id}`
+      );
+    }
+    customReference = `${ge.customRef}/`;
+  }
+  customReference += `${prototype.refCode}${attachmentVersion.customReference}`;
+  return customReference;
+};

--- a/src/lib/data/governingEntities.ts
+++ b/src/lib/data/governingEntities.ts
@@ -102,7 +102,9 @@ const composeCustomReferenceForGoverningEntity = ({
 }): string => {
   const prototype = prototypes.get(governingEntity.entityPrototypeId);
   if (!prototype) {
-    throw new Error('Missing prototype');
+    throw new Error(
+      `Missing prototype for governingEntity ${governingEntity.id}`
+    );
   }
   return `${prototype.refCode}${governingEntityVersion.customReference}`;
 };

--- a/src/lib/data/governingEntities.ts
+++ b/src/lib/data/governingEntities.ts
@@ -1,0 +1,108 @@
+import { EntityPrototypeId } from '../../db/models/entityPrototype';
+import { GoverningEntityId } from '../../db/models/governingEntity';
+import { PlanId } from '../../db/models/plan';
+import { Database } from '../../db/type';
+import { InstanceDataOfModel } from '../../db/util/raw-model';
+import { organizeObjectsByUniqueProperty } from '../../util';
+
+/**
+ * A map from governing entity ids to an object that contains both the
+ * governingEntity and governingEntityVersion for each entry.
+ */
+export type MapOfGoverningEntities = Map<
+  GoverningEntityId,
+  {
+    governingEntity: InstanceDataOfModel<Database['governingEntity']>;
+    governingEntityVersion: InstanceDataOfModel<
+      Database['governingEntityVersion']
+    >;
+    customRef: string;
+  }
+>;
+
+export const getAllGoverningEntitiesForPlan = async ({
+  database,
+  planId,
+  prototypes,
+}: {
+  database: Database;
+  planId: PlanId;
+  version: 'latest';
+  /**
+   * A map of prototypes that **must** include the prototype for governing
+   * entities of this plan.
+   *
+   * Usually the full list of prototypes for a plan is passed in.
+   */
+  prototypes: Map<
+    EntityPrototypeId,
+    InstanceDataOfModel<Database['entityPrototype']>
+  >;
+}): Promise<MapOfGoverningEntities> => {
+  const ges = await database.governingEntity.find({
+    where: {
+      planId,
+    },
+  });
+  const gevs = await database.governingEntityVersion.find({
+    where: (builder) =>
+      builder
+        .whereIn(
+          'governingEntityId',
+          ges.map((ge) => ge.id)
+        )
+        .andWhere('latestVersion', true),
+  });
+  const gevsByGoverningEntityId = organizeObjectsByUniqueProperty(
+    gevs,
+    'governingEntityId'
+  );
+  const result: MapOfGoverningEntities = new Map();
+  for (const governingEntity of ges) {
+    const governingEntityVersion = gevsByGoverningEntityId.get(
+      governingEntity.id
+    );
+    if (!governingEntityVersion) {
+      throw new Error(
+        `Missing governing entity version for ${governingEntity.id}`
+      );
+    }
+    const customRef = composeCustomReferenceForGoverningEntity({
+      governingEntity,
+      governingEntityVersion,
+      prototypes,
+    });
+    result.set(governingEntity.id, {
+      governingEntity,
+      governingEntityVersion,
+      customRef,
+    });
+  }
+  return result;
+};
+
+const composeCustomReferenceForGoverningEntity = ({
+  governingEntity,
+  governingEntityVersion,
+  prototypes,
+}: {
+  governingEntity: InstanceDataOfModel<Database['governingEntity']>;
+  governingEntityVersion: InstanceDataOfModel<
+    Database['governingEntityVersion']
+  >;
+  /**
+   * A map of prototypes that **must** include the prototype for the entity.
+   *
+   * Usually the full list of prototypes for a plan is passed in.
+   */
+  prototypes: Map<
+    EntityPrototypeId,
+    InstanceDataOfModel<Database['entityPrototype']>
+  >;
+}): string => {
+  const prototype = prototypes.get(governingEntity.entityPrototypeId);
+  if (!prototype) {
+    throw new Error('Missing prototype');
+  }
+  return `${prototype.refCode}${governingEntityVersion.customReference}`;
+};

--- a/src/lib/data/planEntities.ts
+++ b/src/lib/data/planEntities.ts
@@ -92,12 +92,14 @@ export const getAndValidateAllPlanEntities = async ({
   for (const planEntity of planEntities) {
     const planEntityVersion = pevsByPlanEntityId.get(planEntity.id);
     if (!planEntityVersion) {
-      throw new Error('Missing plan entity version');
+      throw new Error(
+        `Missing plan entity version for planEntity ${planEntity.id}`
+      );
     }
 
     const prototype = prototypes.get(planEntity.entityPrototypeId);
     if (!prototype) {
-      throw new Error('Missing prototype');
+      throw new Error(`Missing prototype for planEntity ${planEntity.id}`);
     }
 
     const refAndType = getCustomReferenceAndTypeForPlanEntity({
@@ -216,20 +218,22 @@ const getCustomReferenceAndTypeForPlanEntity = ({
 } => {
   const prototype = prototypes.get(planEntity.entityPrototypeId);
   if (!prototype) {
-    throw new Error('Missing prototype');
+    throw new Error(`Missing prototype for planEntity ${planEntity.id}`);
   }
   const parent = entityAssociations.get(planEntity.id);
   let ref = '';
   if (parent) {
     const ge = governingEntities.get(parent.parentId);
     if (!ge) {
-      throw new Error('Missing governing entity');
+      throw new Error(
+        `Missing governing entity for planEntity ${planEntity.id}`
+      );
     }
     ref = `${ge.customRef}/`;
   }
   ref += `${prototype.refCode}${planEntityVersion.customReference}`;
   if (!prototype.refCode) {
-    throw new Error('Missing refCode');
+    throw new Error(`Missing refCode for entityPrototype ${prototype.id}`);
   }
   return {
     customRef: ref,

--- a/src/lib/data/planEntities.ts
+++ b/src/lib/data/planEntities.ts
@@ -61,10 +61,7 @@ export const getAndValidateAllPlanEntities = async ({
   const pevs = await database.planEntityVersion.find({
     where: (builder) =>
       builder
-        .whereIn(
-          'planEntityId',
-          planEntities.map((pe) => pe.id)
-        )
+        .whereIn('planEntityId', [...planEntityIDs])
         .andWhere('latestVersion', true),
   });
   const pevsByPlanEntityId = organizeObjectsByUniqueProperty(
@@ -75,10 +72,7 @@ export const getAndValidateAllPlanEntities = async ({
   const entitiesAssociation = await database.entitiesAssociation.find({
     where: (builder) =>
       builder
-        .whereIn(
-          'childId',
-          planEntities.map((pe) => pe.id)
-        )
+        .whereIn('childId', [...planEntityIDs])
         .andWhere('parentType', 'governingEntity')
         .andWhere('childType', 'planEntity'),
   });

--- a/src/lib/data/planEntities.ts
+++ b/src/lib/data/planEntities.ts
@@ -1,0 +1,238 @@
+import { EntityPrototypeId } from '../../db/models/entityPrototype';
+import { GoverningEntityId } from '../../db/models/governingEntity';
+import { PlanId } from '../../db/models/plan';
+import { PlanEntityId } from '../../db/models/planEntity';
+import { Database } from '../../db/type';
+import { InstanceDataOfModel } from '../../db/util/raw-model';
+import { organizeObjectsByUniqueProperty } from '../../util';
+import { MapOfGoverningEntities } from './governingEntities';
+
+export type ValidatedPlanEntity = {
+  id: PlanEntityId;
+  type: string;
+  customRef: string;
+  description: null | string;
+  /**
+   * List of any entities that this one "supports"
+   * (e.g. specific objectives support strategic objectives)
+   */
+  supports: PlanEntityId[];
+  governingEntity: null | GoverningEntityId;
+};
+
+export type ValidatedPlanEntities = Map<PlanEntityId, ValidatedPlanEntity>;
+
+/**
+ * Get all of the entities for a particular plan,
+ * validate the consistency of data, and return it in a useful format
+ */
+export const getAndValidateAllPlanEntities = async ({
+  database,
+  planId,
+  governingEntities,
+  prototypes,
+}: {
+  database: Database;
+  planId: PlanId;
+  /**
+   * A map from governing entities that include the version to be used when
+   * generating references
+   */
+  governingEntities: MapOfGoverningEntities;
+  version: 'latest';
+  /**
+   * A map of prototypes that **must** include the prototype for governing
+   * entities of this plan.
+   *
+   * Usually the full list of prototypes for a plan is passed in.
+   */
+  prototypes: Map<
+    EntityPrototypeId,
+    InstanceDataOfModel<Database['entityPrototype']>
+  >;
+}): Promise<ValidatedPlanEntities> => {
+  const planEntities = await database.planEntity.find({
+    where: {
+      planId,
+    },
+  });
+  const planEntityIDs = new Set(planEntities.map((pe) => pe.id));
+
+  const pevs = await database.planEntityVersion.find({
+    where: (builder) =>
+      builder
+        .whereIn(
+          'planEntityId',
+          planEntities.map((pe) => pe.id)
+        )
+        .andWhere('latestVersion', true),
+  });
+  const pevsByPlanEntityId = organizeObjectsByUniqueProperty(
+    pevs,
+    'planEntityId'
+  );
+
+  const entitiesAssociation = await database.entitiesAssociation.find({
+    where: (builder) =>
+      builder
+        .whereIn(
+          'childId',
+          planEntities.map((pe) => pe.id)
+        )
+        .andWhere('parentType', 'governingEntity')
+        .andWhere('childType', 'planEntity'),
+  });
+  const eaByChildId = organizeObjectsByUniqueProperty(
+    entitiesAssociation,
+    'childId'
+  );
+
+  const result: ValidatedPlanEntities = new Map();
+
+  for (const planEntity of planEntities) {
+    const planEntityVersion = pevsByPlanEntityId.get(planEntity.id);
+    if (!planEntityVersion) {
+      throw new Error('Missing plan entity version');
+    }
+
+    const prototype = prototypes.get(planEntity.entityPrototypeId);
+    if (!prototype) {
+      throw new Error('Missing prototype');
+    }
+
+    const refAndType = getCustomReferenceAndTypeForPlanEntity({
+      planEntity,
+      planEntityVersion,
+      prototypes,
+      entityAssociations: eaByChildId,
+      governingEntities,
+    });
+
+    const entityDetails: ValidatedPlanEntity = {
+      id: planEntity.id,
+      type: refAndType.type,
+      customRef: refAndType.customRef,
+      description: null,
+      supports: [],
+      governingEntity: eaByChildId.get(planEntity.id)?.parentId || null,
+    };
+
+    // Use entity details if possible
+    if (planEntityVersion.value) {
+      // Able to inspect entity details
+      entityDetails.description = planEntityVersion.value.description;
+      const supportingPlanEntityIds = planEntityVersion.value.support.flatMap(
+        (s) => s.planEntityIds
+      );
+      // Check that the list of planEntityIds is valid
+      const missing = supportingPlanEntityIds.filter(
+        (id) => !planEntityIDs.has(id)
+      );
+      if (missing.length > 0) {
+        throw new Error(
+          `Missing supporting planEntityIds: ${missing.join(', ')}`
+        );
+      }
+
+      // TODO: Check that the plan entities pass the canSupport requirements
+      // specified in the prototype, including matching the cardinality
+      entityDetails.supports = supportingPlanEntityIds;
+    }
+
+    result.set(entityDetails.id, entityDetails);
+  }
+
+  return result;
+};
+
+/**
+ * Given a particular plan entity,
+ * return a list of all entity IDs that it supports, and any that they support,
+ * etc... including the ID of the plan entity itself
+ */
+export const calculateReflectiveTransitiveEntitySupport = ({
+  planEntity,
+  planEntities,
+}: {
+  planEntity: ValidatedPlanEntity;
+  planEntities: ValidatedPlanEntities;
+}): Set<PlanEntityId> => {
+  const supportsEntitiesIDs: Set<PlanEntityId> = new Set();
+  const entities = [planEntity];
+  let entity: ValidatedPlanEntity | undefined;
+  while ((entity = entities.pop())) {
+    // Prevent loops by skipping entities we have already processed
+    if (supportsEntitiesIDs.has(entity.id)) {
+      continue;
+    }
+    supportsEntitiesIDs.add(entity.id);
+    for (const supportedEntity of entity.supports) {
+      const e = planEntities.get(supportedEntity);
+      if (!e) {
+        throw new Error(`Missing plan entity ${supportedEntity}`);
+      }
+      entities.push(e);
+    }
+  }
+  return supportsEntitiesIDs;
+};
+
+const getCustomReferenceAndTypeForPlanEntity = ({
+  planEntity,
+  planEntityVersion,
+  prototypes,
+  entityAssociations,
+  governingEntities,
+}: {
+  planEntity: InstanceDataOfModel<Database['planEntity']>;
+  planEntityVersion: InstanceDataOfModel<Database['planEntityVersion']>;
+  /**
+   * A map of prototypes that **must** include the prototype for the entity.
+   *
+   * Usually the full list of prototypes for a plan is passed in.
+   */
+  prototypes: Map<
+    EntityPrototypeId,
+    InstanceDataOfModel<Database['entityPrototype']>
+  >;
+  /**
+   * A map of associations from the `entitiesAssociation` table, that **must**
+   * include any rows that reference this entity.
+   */
+  entityAssociations: Map<
+    PlanEntityId,
+    InstanceDataOfModel<Database['entitiesAssociation']>
+  >;
+  /**
+   * A map from governing entity IDs to an object containing the .
+   *
+   * This may **must** include any governing entity referenced by the entity,
+   * usually the full list of governing entities for a plan is passed in.
+   */
+  governingEntities: MapOfGoverningEntities;
+}): {
+  customRef: string;
+  type: string;
+} => {
+  const prototype = prototypes.get(planEntity.entityPrototypeId);
+  if (!prototype) {
+    throw new Error('Missing prototype');
+  }
+  const parent = entityAssociations.get(planEntity.id);
+  let ref = '';
+  if (parent) {
+    const ge = governingEntities.get(parent.parentId);
+    if (!ge) {
+      throw new Error('Missing governing entity');
+    }
+    ref = `${ge.customRef}/`;
+  }
+  ref += `${prototype.refCode}${planEntityVersion.customReference}`;
+  if (!prototype.refCode) {
+    throw new Error('Missing refCode');
+  }
+  return {
+    customRef: ref,
+    type: prototype.refCode,
+  };
+};

--- a/src/lib/data/projects.ts
+++ b/src/lib/data/projects.ts
@@ -69,12 +69,14 @@ export async function getAllProjectsForPlan({
     // Sanity check that the project version is actually associated with
     // this project
     if (projectVersion.projectId !== project.id) {
-      throw new Error('Data inconsistency found');
+      throw new Error(`Data inconsistency found for project ${project.id}`);
     }
     const pvp = pvpsByProjectVersionId.get(projectVersion.id);
     /* istanbul ignore if - this should not occur*/
     if (!pvp) {
-      throw new Error('Unexpected error');
+      throw new Error(
+        `Missing projectVersionPlan for projectVersion ${projectVersion.id}`
+      );
     }
     const workflowStatus =
       (pvp.workflowStatusOptionId &&

--- a/src/lib/data/projects.ts
+++ b/src/lib/data/projects.ts
@@ -1,0 +1,91 @@
+import { PlanId } from '../../db/models/plan';
+import { ProjectId } from '../../db/models/project';
+import { Database } from '../../db/type';
+import { InstanceOfModel } from '../../db/util/types';
+import { isDefined, organizeObjectsByUniqueProperty } from '../../util';
+
+export interface ProjectData {
+  project: InstanceOfModel<Database['project']>;
+  projectVersion: InstanceOfModel<Database['projectVersion']>;
+  workflowStatus: InstanceOfModel<Database['workflowStatusOption']> | null;
+}
+
+export async function getAllProjectsForPlan({
+  database,
+  planId,
+}: {
+  database: Database;
+  planId: PlanId;
+  version: 'latest';
+}): Promise<Map<ProjectId, ProjectData>> {
+  const pvps = await database.projectVersionPlan.find({
+    where: {
+      planId,
+    },
+  });
+  const pvpsByProjectVersionId = organizeObjectsByUniqueProperty(
+    pvps,
+    'projectVersionId'
+  );
+  const projectVersions = await database.projectVersion.find({
+    where: (builder) =>
+      builder.whereIn('id', [
+        ...new Set(pvps.map((pvp) => pvp.projectVersionId)),
+      ]),
+  });
+  const pvsById = organizeObjectsByUniqueProperty(projectVersions, 'id');
+  const projects = await database.project.find({
+    where: (builder) =>
+      builder.whereIn('id', [
+        ...new Set(projectVersions.map((pv) => pv.projectId)),
+      ]),
+  });
+  const workflowStatuses = await database.workflowStatusOption.find({
+    where: (builder) =>
+      builder.whereIn(
+        'id',
+        [...new Set(pvps.map((pvp) => pvp.workflowStatusOptionId))].filter(
+          isDefined
+        )
+      ),
+  });
+  const workflowStatusById = organizeObjectsByUniqueProperty(
+    workflowStatuses,
+    'id'
+  );
+
+  const result = new Map<ProjectId, ProjectData>();
+  for (const project of projects) {
+    if (!project.latestVersionId) {
+      // Project only has ID and no base data yet, ignore
+      continue;
+    }
+    const projectVersion = pvsById.get(project.latestVersionId);
+    if (!projectVersion) {
+      // Project likely has older version assigned to plan but not current
+      // version, okay to ignore
+      continue;
+    }
+    // Sanity check that the project version is actually associated with
+    // this project
+    if (projectVersion.projectId !== project.id) {
+      throw new Error('Data inconsistency found');
+    }
+    const pvp = pvpsByProjectVersionId.get(projectVersion.id);
+    /* istanbul ignore if - this should not occur*/
+    if (!pvp) {
+      throw new Error('Unexpected error');
+    }
+    const workflowStatus =
+      (pvp.workflowStatusOptionId &&
+        workflowStatusById.get(pvp.workflowStatusOptionId)) ||
+      null;
+    result.set(project.id, {
+      project,
+      projectVersion,
+      workflowStatus,
+    });
+  }
+
+  return result;
+}


### PR DESCRIPTION
Following on from #32

https://github.com/UN-OCHA/hpc_service/pull/2439 Introduces a number of general-purpose functions for reading and validating particular sets of data from the database that will likely need to be used when implementing certain functionality in the new v4 API. Rather than have them live in just hpc_service, given that they already only use the v4 models, they may as well live in this repo.

@Pl217 thoughts?