### PR TITLE
Specify `@types/lodash` and `@types/node-fetch` as regular dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,8 @@
     "lint": "yarn lint-prettier && yarn lint-eslint"
   },
   "dependencies": {
+    "@types/lodash": "^4.14.170",
+    "@types/node-fetch": "^2.5.12",
     "fp-ts": "^2.6.6",
     "io-ts": "2.2.9",
     "knex": "0.21.1",
@@ -20,9 +22,7 @@
     "pg": "^8.5.1"
   },
   "devDependencies": {
-    "@types/lodash": "^4.14.170",
     "@types/node": "^14.0.5",
-    "@types/node-fetch": "^2.5.12",
     "@unocha/hpc-repo-tools": "^0.1.5",
     "eslint": "8.1.0",
     "husky": "^7.0.2",


### PR DESCRIPTION
If `@types/lodash` and `@types/node-fetch` remain `devDependencies`, all projects using `hpc-api-core` would need to install them.

Instead of specifying them as `peerDependencies` and relying on package users to install the dependencies, let's make `hpc-api-core` a full package, that should just be installed and used.

[New API](https://github.com/UN-OCHA/hpc-api) does not have `@types/lodash` and `@types/node-fetch` installed and [CI fails](https://github.com/UN-OCHA/hpc-api/runs/4105966984?check_suite_focus=true) because TS type checks are failing.