### PR TITLE
🎨 Use new db util functions for consistent errors

### DIFF
--- a/src/db/fetching.ts
+++ b/src/db/fetching.ts
@@ -1,0 +1,63 @@
+import { AnnotatedMap, organizeObjectsByUniqueValue } from '../util';
+import { Database } from './type';
+import { InstanceDataOfModel, Model } from './util/raw-model';
+import {
+  InstanceOfVersionedModel,
+  VersionedModel,
+} from './util/versioned-model';
+
+/**
+ * Generic type that can be used to obtain the type of an instance of either a
+ * standard table, or a versioned table.
+ */
+type InstanceOf<T extends Database[keyof Database]> = T extends Model<any>
+  ? InstanceDataOfModel<T>
+  : T extends VersionedModel<any, any, any>
+  ? InstanceOfVersionedModel<T>
+  : never;
+
+/**
+ * Fetch a number of items of a particular type from the database,
+ * and organize them into an AnnotatedMap by a unique property.
+ *
+ * The property selected must non-null for every instance retrieved from the
+ * database, otherwise an error will be thrown
+ */
+export const findAndOrganizeObjectsByUniqueProperty = <
+  Table extends Database[keyof Database],
+  P extends keyof InstanceOf<Table>
+>(
+  table: Table,
+  fetch: (tbl: Table) => Promise<Iterable<InstanceOf<Table>>>,
+  property: P
+): Promise<
+  AnnotatedMap<Exclude<InstanceOf<Table>[P], null>, InstanceOf<Table>>
+> => {
+  return findAndOrganizeObjectsByUniqueValue(table, fetch, (item) => {
+    const val = item[property];
+    if (val === null) {
+      throw new Error(`Unexpected null value in ${property} for ${item}`);
+    }
+    return val as Exclude<InstanceOf<Table>[P], null>;
+  });
+};
+
+/**
+ * Fetch a number of items of a particular type from the database,
+ * and organize them into an AnnotatedMap by a unique value.
+ */
+export const findAndOrganizeObjectsByUniqueValue = async <
+  Table extends Database[keyof Database],
+  V
+>(
+  table: Table,
+  fetch: (tbl: Table) => Promise<Iterable<InstanceOf<Table>>>,
+  getValue: (i: InstanceOf<Table>) => Exclude<V, null>
+): Promise<AnnotatedMap<Exclude<V, null>, InstanceOf<Table>>> => {
+  const values = await fetch(table);
+  const tableName =
+    table._internals.type === 'single-table'
+      ? table._internals.tableName
+      : table._internals.root.tableName;
+  return organizeObjectsByUniqueValue(values, getValue, tableName);
+};

--- a/src/db/util/validation.ts
+++ b/src/db/util/validation.ts
@@ -153,7 +153,13 @@ export const dataValidator = <F extends FieldDefinition>(
   ): Instance => {
     const decoded = instanceValidator.decode(val);
     if (isRight(decoded)) {
-      return decoded.right;
+      const val = decoded.right;
+      Object.defineProperty(val, 'toString', {
+        value: genIdentifier,
+        writable: false,
+        enumerable: false,
+      });
+      return val;
     } else {
       const errors = ioTsErrorFormatter(decoded);
       throw new DataValidationError({

--- a/src/db/util/versioned-model.ts
+++ b/src/db/util/versioned-model.ts
@@ -46,7 +46,7 @@ type RootColumnDefinition<
   };
 };
 
-type VersionedModel<
+export type VersionedModel<
   IDType,
   Data,
   LookupColumns extends LookupColumnDefinition
@@ -183,7 +183,7 @@ export const defineVersionedModel =
       },
       genIdentifier: (data) => {
         if (hasRootAndVersion(data)) {
-          return `${name}Version ${data.root}-${data.version}`;
+          return `${name}Version ${data.root}-v${data.version}`;
         } else {
           return `unknown ${name}Version`;
         }
@@ -198,20 +198,28 @@ export const defineVersionedModel =
       root: { id: IDType };
       data: Data;
       version: InstanceDataOfModel<typeof versionModel>;
-    }): VersionedInstance<IDType, Data> => ({
-      id,
-      version: version.version,
-      modifiedBy: version.modifiedBy || null,
-      modifiedAt: version.updatedAt,
-      data,
-      update: (data, modifiedBy) =>
-        result.update({
-          id,
-          currentVersion: version.version,
-          data,
-          modifiedBy,
-        }),
-    });
+    }): VersionedInstance<IDType, Data> => {
+      const instance: VersionedInstance<IDType, Data> = {
+        id,
+        version: version.version,
+        modifiedBy: version.modifiedBy || null,
+        modifiedAt: version.updatedAt,
+        data,
+        update: (data, modifiedBy) =>
+          result.update({
+            id,
+            currentVersion: version.version,
+            data,
+            modifiedBy,
+          }),
+      };
+      Object.defineProperty(instance, 'toString', {
+        value: () => `${name}Version ${id}-v${version.version}`,
+        writable: false,
+        enumerable: false,
+      });
+      return instance;
+    };
 
     const result: VersionedModel<IDType, Data, LookupColumns> = {
       _internals: {

--- a/src/util/index.ts
+++ b/src/util/index.ts
@@ -74,6 +74,13 @@ export type PromiseType<P extends Promise<any>> = P extends Promise<infer V>
   : never;
 
 /**
+ * A map with additional information stored about the items contained within.
+ */
+export type AnnotatedMap<K, V> = Map<K, V> & {
+  _objectType: string;
+};
+
+/**
  * Take a collection of objects,
  * and group them by one of their properties
  */
@@ -121,10 +128,34 @@ export const organizeObjectsByUniqueProperty = <I, P extends keyof I>(
  * using a particular function to derive the key
  * that should be used for each object
  */
-export const organizeObjectsByUniqueValue = <I, V>(
+export function organizeObjectsByUniqueValue<I, V>(
   objects: Iterable<I>,
   getValue: (i: I) => V
-): Map<V, I> => {
+): Map<V, I>;
+
+/**
+ * Take a collection of objects,
+ * and create a map of them,
+ * using a particular function to derive the key
+ * that should be used for each object
+ *
+ * This variation also specified a string that should be used to identify the
+ * type of object contained within the map
+ */
+export function organizeObjectsByUniqueValue<I, V>(
+  objects: Iterable<I>,
+  getValue: (i: I) => V,
+  /**
+   * The string that should be used to identify the type of object contained
+   */
+  objectType: string
+): AnnotatedMap<V, I>;
+
+export function organizeObjectsByUniqueValue<I, V>(
+  objects: Iterable<I>,
+  getValue: (i: I) => V,
+  objectType?: string
+): Map<V, I> {
   const result = new Map<V, I>();
   for (const obj of objects) {
     const value = getValue(obj);
@@ -134,8 +165,14 @@ export const organizeObjectsByUniqueValue = <I, V>(
     }
     result.set(value, obj);
   }
+  if (objectType) {
+    Object.defineProperty(result, '_objectType', {
+      value: objectType,
+      writable: false,
+    });
+  }
   return result;
-};
+}
 
 /**
  * Return a new object with the given map function applies to all values


### PR DESCRIPTION
Following on from the discussion in https://github.com/UN-OCHA/hpc-api-core/pull/33#discussion_r742675345

Introduce and use new `findAndOrganizeObjectsByUniqueProperty`, `findAndOrganizeObjectsByUniqueValue` and `getRequiredData` functions to consistently check for the existence of certain objects in maps, and fail with an error including relevant identifiable information if they are not found.

This required quite a bit of extra work and a couple of type hacks to get working correctly with as much type-safety as possible.

I spent way too long on this, and ultimately, I'm not convinced that it's worth the additional complexity / abstractions that this adds. It bulks up the util modules with quite a lot of extra cruft, though it does mean the error messages we produce are much more consistent...

Regardless as to whether we want to go with this in the end, it's probably worthwhile at least including 4cfef6f585a0fa4e63c721ad4256b66b86e9961f, which will allow for easier debugging and logging anyway. (Maybe we just keep that and simplify the errors by just including the entity in the error string?

I think before merging this, we should get a couple of other people's opinions on it, if it's too complex, doesn't make sense, let's maybe drop it.

This was a fun little experiment at least 😅 