### PR TITLE
Accept `null` for `optional` user data

### DIFF
--- a/src/db/util/model-definition.ts
+++ b/src/db/util/model-definition.ts
@@ -77,5 +77,5 @@ export type UserDataOf<F extends FieldDefinition> = Partial<
   FieldValuesOfSet<F['nonNullWithDefault']>
 > &
   FieldValuesOfSet<F['required']> &
-  Partial<FieldValuesOfSet<F['optional']>> &
-  FieldValuesOfSet<F['accidentallyOptional']>;
+  FieldValuesOfSet<F['accidentallyOptional']> &
+  Partial<Nullable<FieldValuesOfSet<F['optional']>>>;


### PR DESCRIPTION
First, `null` should be accepted as user data for `optional` fields. Optional columns are `NULL`-able, so accepting `T | null | undefined` is pretty reasonable.

Other change relates to `accidentallyOptional` in model instances not being treated as nullable, so instead of `T | null`, we will have just `T` (same as old `seqelize` models). Accidentally optional is basically specifying loopholes that never got exploited. The main question is whether we want to validate these fields as nullable as well - [this line](https://github.com/UN-OCHA/hpc-api-core/blob/1c1c8fdeb8adcfe8e33d1757517275255afdce2d/src/db/util/validation.ts#L147).

Without these changes, constructs like this cannot pass type checks:
```ts
const plan = await models.v4.plan.findOne({
  where: { id: createBrandedValue(1) },
});

if (!plan) {
  throw new Error();
}

await models.v4.plan.create({ ...plan });
```

This is needed for https://github.com/UN-OCHA/hpc_service/pull/2445