### PR TITLE
Define more error classes

### DIFF
--- a/src/util/error.ts
+++ b/src/util/error.ts
@@ -85,6 +85,32 @@ type ErrorBody = {
   message: string;
 };
 
+export class BadRequestError extends ExtendableError {
+  private readonly _originalError?: Error;
+  private readonly body: ErrorBody;
+  private readonly statusCode: StatusCode;
+
+  constructor(message: string, originalError?: Error) {
+    super(message);
+
+    /*
+     * Due to a known issue (https://github.com/microsoft/TypeScript/issues/13965)
+     * we need to set prototype manually, in order to get `instanceof` to work
+     * for classes that extend `Error`
+     */
+    Object.setPrototypeOf(this, BadRequestError.prototype);
+
+    this.name = this.constructor.name;
+    this.statusCode = STATUS_CODES.BAD_REQUEST;
+
+    if (originalError) {
+      this._originalError = originalError;
+    }
+
+    this.body = { status: 'error', code: this.name, message };
+  }
+}
+
 export class ForbiddenError extends ExtendableError {
   private readonly _originalError?: Error;
   private readonly body: ErrorBody;

--- a/src/util/error.ts
+++ b/src/util/error.ts
@@ -162,3 +162,29 @@ export class NotFoundError extends ExtendableError {
     this.body = { status: 'error', code: this.name, message };
   }
 }
+
+export class PreconditionFailedError extends ExtendableError {
+  private readonly _originalError?: Error;
+  private readonly body: ErrorBody;
+  private readonly statusCode: StatusCode;
+
+  constructor(message: string, originalError?: Error) {
+    super(message);
+
+    /*
+     * Due to a known issue (https://github.com/microsoft/TypeScript/issues/13965)
+     * we need to set prototype manually, in order to get `instanceof` to work
+     * for classes that extend `Error`
+     */
+    Object.setPrototypeOf(this, PreconditionFailedError.prototype);
+
+    this.name = this.constructor.name;
+    this.statusCode = STATUS_CODES.PRECONDITION_FAILED;
+
+    if (originalError) {
+      this._originalError = originalError;
+    }
+
+    this.body = { status: 'error', code: this.name, message };
+  }
+}

--- a/src/util/error.ts
+++ b/src/util/error.ts
@@ -136,3 +136,29 @@ export class ForbiddenError extends ExtendableError {
     this.body = { status: 'error', code: this.name, message };
   }
 }
+
+export class NotFoundError extends ExtendableError {
+  private readonly _originalError?: Error;
+  private readonly body: ErrorBody;
+  private readonly statusCode: StatusCode;
+
+  constructor(message: string, originalError?: Error) {
+    super(message);
+
+    /*
+     * Due to a known issue (https://github.com/microsoft/TypeScript/issues/13965)
+     * we need to set prototype manually, in order to get `instanceof` to work
+     * for classes that extend `Error`
+     */
+    Object.setPrototypeOf(this, NotFoundError.prototype);
+
+    this.name = this.constructor.name;
+    this.statusCode = STATUS_CODES.NOT_FOUND;
+
+    if (originalError) {
+      this._originalError = originalError;
+    }
+
+    this.body = { status: 'error', code: this.name, message };
+  }
+}


### PR DESCRIPTION
Define `BadRequestError`, `NotFoundError` and `PreconditionFailedError`.

Since #48 is not yet merged, I plan to release this change under the same version (`v0.6.0`) which is bumped in #48.