### PR TITLE
Reduce precision of knex updatedAt and createdAt to 3

### DIFF
--- a/src/db/util/sequelize-model.ts
+++ b/src/db/util/sequelize-model.ts
@@ -96,8 +96,8 @@ export const defineSequelizeModel =
       return model.create(
         {
           ...data,
-          createdAt: conn.fn.now(),
-          updatedAt: conn.fn.now(),
+          createdAt: conn.fn.now(3),
+          updatedAt: conn.fn.now(3),
         },
         opts
       );
@@ -108,7 +108,7 @@ export const defineSequelizeModel =
         ...args,
         values: {
           ...args.values,
-          updatedAt: conn.fn.now(),
+          updatedAt: conn.fn.now(3),
         },
       });
     };


### PR DESCRIPTION
There is a problem with mismatching date precision between sequelize and knex models. For example, when editing a project the following code returns `null` because `projectData` is returned by sequelize and doesn't include microseconds
```
  let project = await models.v4.project.findOne({
    where: {
      id: projectId,
      updatedAt: projectData.updatedAt,
    },
  });
  ```
  This PR reduces the precision of knex `createdAt` and `updatedAt` dates to milliseconds rather than microseconds