### PR TITLE
Define bigint and numeric columns as a union of string and number

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@unocha/hpc-api-core",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "Core libraries supporting HPC.Tools API Backend",
   "license": "Apache-2.0",
   "private": false,

--- a/src/db/models/flow.ts
+++ b/src/db/models/flow.ts
@@ -47,7 +47,15 @@ export default defineIDModel({
        */
       origAmount: { kind: 'checked', type: t.union([t.string, t.number]) },
       origCurrency: { kind: 'checked', type: t.string },
-      exchangeRate: { kind: 'checked', type: t.number },
+      /**
+       * Union type of string and number is used because numeric DB type
+       * is read as string, but when inserting rows, we don't want
+       * library clients to provide numbers as strings.
+       *
+       * TODO: Add the possibility to define separate types for reading
+       * and writing, then use string for reading and number for writing
+       */
+      exchangeRate: { kind: 'checked', type: t.union([t.string, t.number]) },
       description: { kind: 'checked', type: t.string },
       notes: { kind: 'checked', type: t.string },
       versionStartDate: { kind: 'checked', type: DATE },

--- a/src/db/models/flow.ts
+++ b/src/db/models/flow.ts
@@ -16,7 +16,15 @@ export default defineIDModel({
       id: { kind: 'branded-integer', brand: FLOW_ID },
     },
     required: {
-      amountUSD: { kind: 'checked', type: t.bigint },
+      /**
+       * Union type of string and number is used because int8 (bigint)
+       * DB type is read as string, but when inserting rows, we don't want
+       * library clients to provide numbers as strings.
+       *
+       * TODO: Add the possibility to define separate types for reading
+       * and writing, then use string for reading and number for writing
+       */
+      amountUSD: { kind: 'checked', type: t.union([t.string, t.number]) },
     },
     nonNullWithDefault: {
       versionID: { kind: 'checked', type: t.number },
@@ -29,7 +37,15 @@ export default defineIDModel({
       decisionDate: { kind: 'checked', type: DATE },
       firstReportedDate: { kind: 'checked', type: DATE },
       budgetYear: { kind: 'checked', type: t.string },
-      origAmount: { kind: 'checked', type: t.bigint },
+      /**
+       * Union type of string and number is used because int8 (bigint)
+       * DB type is read as string, but when inserting rows, we don't want
+       * library clients to provide numbers as strings.
+       *
+       * TODO: Add the possibility to define separate types for reading
+       * and writing, then use string for reading and number for writing
+       */
+      origAmount: { kind: 'checked', type: t.union([t.string, t.number]) },
       origCurrency: { kind: 'checked', type: t.string },
       exchangeRate: { kind: 'checked', type: t.number },
       description: { kind: 'checked', type: t.string },

--- a/src/db/models/location.ts
+++ b/src/db/models/location.ts
@@ -35,7 +35,15 @@ export default defineIDModel({
       longitude: { kind: 'checked', type: t.number },
       iso3: { kind: 'checked', type: t.string },
       pcode: { kind: 'checked', type: t.string },
-      validOn: { kind: 'checked', type: t.bigint },
+      /**
+       * Union type of string and number is used because int8 (bigint)
+       * DB type is read as string, but when inserting rows, we don't want
+       * library clients to provide numbers as strings.
+       *
+       * TODO: Add the possibility to define separate types for reading
+       * and writing, then use string for reading and number for writing
+       */
+      validOn: { kind: 'checked', type: t.union([t.string, t.number]) },
       parentId: { kind: 'branded-integer', brand: LOCATION_ID },
     },
     accidentallyOptional: {

--- a/src/db/models/projectVersion.ts
+++ b/src/db/models/projectVersion.ts
@@ -16,6 +16,14 @@ export default defineIDModel({
       id: { kind: 'branded-integer', brand: PROJECT_VERSION_ID },
     },
     optional: {
+      /**
+       * Union type of string and number is used because int8 (bigint)
+       * DB type is read as string, but when inserting rows, we don't want
+       * library clients to provide numbers as strings.
+       *
+       * TODO: Add the possibility to define separate types for reading
+       * and writing, then use string for reading and number for writing
+       */
       currentRequestedFunds: {
         kind: 'checked',
         type: t.union([t.string, t.number]),


### PR DESCRIPTION
Idea to use `BigInt` type for columns defined as int8 (bigint) was a good one, but requires `pg` serialization changes, which affect old sequelize models, not only new knex models.

This switch would not be a walk in the park, especially since there are lots of legacy code working with financial data, which would suddenly need to be differently typed. Since it was read as strings previously, it is natural to expect `parseInt` conversions in lots of places, and luckily `parseInt(217n)` evaluates to `217`, but then again, there are lots of operations with these numbers, where I don't feel confident that transition would be smooth. And given the problems we've seen over time with financial data, I don't want to cause even more trouble.

I am not willing to make lots of changes now to the legacy code. Thus, I think we should explore the idea of defining different codecs for reading and writing, which would not only be useful when reading numbers represented as strings, but also in lots of JSON codecs, where we've seen wild constructs to accommodate already existing data, which is often dirty, and new data should definitely not store data in such manner any longer.