### PR TITLE
Define `createMany` for sequelize models

### DIFF
--- a/src/db/util/sequelize-model.ts
+++ b/src/db/util/sequelize-model.ts
@@ -9,6 +9,7 @@ import {
   defineRawModel,
   ModelInitializer,
   CreateFn,
+  CreateManyFn,
   UpdateFn,
 } from './raw-model';
 import { FieldDefinition } from './model-definition';
@@ -103,6 +104,17 @@ export const defineSequelizeModel =
       );
     };
 
+    const createMany: CreateManyFn<Fields> = (data, opts) => {
+      return model.createMany(
+        data.map((data) => ({
+          ...data,
+          createdAt: conn.fn.now(3),
+          updatedAt: conn.fn.now(3),
+        })),
+        opts
+      );
+    };
+
     const update: UpdateFn<Fields> = (args) => {
       return model.update({
         ...args,
@@ -116,6 +128,7 @@ export const defineSequelizeModel =
     return {
       ...model,
       create,
+      createMany,
       update,
     };
   };


### PR DESCRIPTION
This was missed to be added in 9847f580f8732b056a916bca94ece4ff8e9f658f and the queries were failing because of non-null constraints being violated.