### PR TITLE
✨ Introduce new custom where condition construction 

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@unocha/hpc-api-core",
-  "version": "0.10.0",
+  "version": "1.0.0",
   "description": "Core libraries supporting HPC.Tools API Backend",
   "license": "Apache-2.0",
   "private": false,

--- a/src/db/fetching.ts
+++ b/src/db/fetching.ts
@@ -1,3 +1,4 @@
+import { UTILS } from '.';
 import { AnnotatedMap, organizeObjectsByUniqueValue } from '../util';
 import { Database } from './type';
 import { InstanceDataOfModel, Model } from './util/raw-model';
@@ -24,7 +25,7 @@ type InstanceOf<T extends Database[keyof Database]> = T extends Model<any>
  * database, otherwise an error will be thrown
  */
 export const findAndOrganizeObjectsByUniqueProperty = <
-  Table extends Database[keyof Database],
+  Table extends Database[keyof Omit<Database, keyof typeof UTILS>],
   P extends keyof InstanceOf<Table>
 >(
   table: Table,
@@ -47,7 +48,7 @@ export const findAndOrganizeObjectsByUniqueProperty = <
  * and organize them into an AnnotatedMap by a unique value.
  */
 export const findAndOrganizeObjectsByUniqueValue = async <
-  Table extends Database[keyof Database],
+  Table extends Database[keyof Omit<Database, keyof typeof UTILS>],
   V
 >(
   table: Table,

--- a/src/db/fetching.ts
+++ b/src/db/fetching.ts
@@ -1,6 +1,5 @@
-import { UTILS } from '.';
+import { Table } from '.';
 import { AnnotatedMap, organizeObjectsByUniqueValue } from '../util';
-import { Database } from './type';
 import { InstanceDataOfModel, Model } from './util/raw-model';
 import {
   InstanceOfVersionedModel,
@@ -11,7 +10,7 @@ import {
  * Generic type that can be used to obtain the type of an instance of either a
  * standard table, or a versioned table.
  */
-type InstanceOf<T extends Database[keyof Database]> = T extends Model<any>
+type InstanceOf<T extends Table> = T extends Model<any>
   ? InstanceDataOfModel<T>
   : T extends VersionedModel<any, any, any>
   ? InstanceOfVersionedModel<T>
@@ -25,21 +24,19 @@ type InstanceOf<T extends Database[keyof Database]> = T extends Model<any>
  * database, otherwise an error will be thrown
  */
 export const findAndOrganizeObjectsByUniqueProperty = <
-  Table extends Database[keyof Omit<Database, keyof typeof UTILS>],
-  P extends keyof InstanceOf<Table>
+  T extends Table,
+  P extends keyof InstanceOf<T>
 >(
-  table: Table,
-  fetch: (tbl: Table) => Promise<Iterable<InstanceOf<Table>>>,
+  table: T,
+  fetch: (tbl: T) => Promise<Iterable<InstanceOf<T>>>,
   property: P
-): Promise<
-  AnnotatedMap<Exclude<InstanceOf<Table>[P], null>, InstanceOf<Table>>
-> => {
+): Promise<AnnotatedMap<Exclude<InstanceOf<T>[P], null>, InstanceOf<T>>> => {
   return findAndOrganizeObjectsByUniqueValue(table, fetch, (item) => {
     const val = item[property];
     if (val === null) {
       throw new Error(`Unexpected null value in ${property} for ${item}`);
     }
-    return val as Exclude<InstanceOf<Table>[P], null>;
+    return val as Exclude<InstanceOf<T>[P], null>;
   });
 };
 
@@ -47,14 +44,11 @@ export const findAndOrganizeObjectsByUniqueProperty = <
  * Fetch a number of items of a particular type from the database,
  * and organize them into an AnnotatedMap by a unique value.
  */
-export const findAndOrganizeObjectsByUniqueValue = async <
-  Table extends Database[keyof Omit<Database, keyof typeof UTILS>],
-  V
->(
-  table: Table,
-  fetch: (tbl: Table) => Promise<Iterable<InstanceOf<Table>>>,
-  getValue: (i: InstanceOf<Table>) => Exclude<V, null>
-): Promise<AnnotatedMap<Exclude<V, null>, InstanceOf<Table>>> => {
+export const findAndOrganizeObjectsByUniqueValue = async <T extends Table, V>(
+  table: T,
+  fetch: (tbl: T) => Promise<Iterable<InstanceOf<T>>>,
+  getValue: (i: InstanceOf<T>) => Exclude<V, null>
+): Promise<AnnotatedMap<Exclude<V, null>, InstanceOf<T>>> => {
   const values = await fetch(table);
   const tableName =
     table._internals.type === 'single-table'

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -95,8 +95,19 @@ import unitType from './models/unitType';
 import usageYear from './models/usageYear';
 import workflowStatusOption from './models/workflowStatusOption';
 import workflowStatusOptionStep from './models/workflowStatusOptionStep';
+import { Op, Cond } from './util/conditions';
+
+/**
+ * Utilities that are frequently used, and should also be included as part of
+ * the model root for easy access.
+ */
+export const UTILS = {
+  Op,
+  Cond,
+};
 
 export default (conn: Knex) => ({
+  ...UTILS,
   attachment: attachment(conn),
   attachmentPrototype: attachmentPrototype(conn),
   attachmentVersion: attachmentVersion(conn),

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -106,8 +106,7 @@ export const UTILS = {
   Cond,
 };
 
-export default (conn: Knex) => ({
-  ...UTILS,
+const initializeTables = (conn: Knex) => ({
   attachment: attachment(conn),
   attachmentPrototype: attachmentPrototype(conn),
   attachmentVersion: attachmentVersion(conn),
@@ -205,3 +204,26 @@ export default (conn: Knex) => ({
   workflowStatusOption: workflowStatusOption(conn),
   workflowStatusOptionStep: workflowStatusOptionStep(conn),
 });
+
+export type Tables = ReturnType<typeof initializeTables>;
+
+export type Table = Tables[keyof Tables];
+
+const initializeRoot = (conn: Knex) => {
+  const _tables = initializeTables(conn);
+  return {
+    ...UTILS,
+    ..._tables,
+    /**
+     * Expose the tables grouped together under one object under the root to
+     * allow for easier iteration through each of them.
+     *
+     * (this is used in unit tests)
+     */
+    _tables,
+  };
+};
+
+export type Database = ReturnType<typeof initializeRoot>;
+
+export default initializeRoot;

--- a/src/db/type.ts
+++ b/src/db/type.ts
@@ -1,3 +1,1 @@
-import type db from '.';
-
-export type Database = ReturnType<typeof db>;
+export type { Database } from '.';

--- a/src/db/util/conditions.ts
+++ b/src/db/util/conditions.ts
@@ -6,7 +6,7 @@ import Knex = require('knex');
 /**
  * Symbols to use for where condition construction
  */
-namespace ConditionSymbols {
+export namespace ConditionSymbols {
   export const BUILDER = Symbol('builder');
   export const AND = Symbol('and');
   export const OR = Symbol('or');
@@ -26,7 +26,7 @@ export const Cond = ConditionSymbols.Cond;
 /**
  * Symbols to use when constructing conditions for a single property
  */
-namespace PropertySymbols {
+export namespace PropertySymbols {
   export const IN = Symbol('in');
   export const NOT_IN = Symbol('not in');
 

--- a/src/db/util/conditions.ts
+++ b/src/db/util/conditions.ts
@@ -44,10 +44,10 @@ export const Op = PropertySymbols.Op;
 namespace PropertyConditions {
   export type EqualityCondition<T> = T;
   export type InCondition<T> = {
-    [Op.IN]: T[];
+    [Op.IN]: Iterable<T>;
   };
   export type NotInCondition<T> = {
-    [Op.NOT_IN]: T[];
+    [Op.NOT_IN]: Iterable<T>;
   };
   /**
    * A condition that must hold over a single property whose type is T
@@ -167,9 +167,9 @@ export const prepareCondition =
         if (PropertyConditions.isEqualityCondition(propertyCondition)) {
           builder.where(property, propertyCondition);
         } else if (PropertyConditions.isInCondition(propertyCondition)) {
-          builder.whereIn(property, propertyCondition[Op.IN]);
+          builder.whereIn(property, [...propertyCondition[Op.IN]]);
         } else if (PropertyConditions.isNotInCondition(propertyCondition)) {
-          builder.whereNotIn(property, propertyCondition[Op.NOT_IN]);
+          builder.whereNotIn(property, [...propertyCondition[Op.NOT_IN]]);
         } else {
           throw new Error(`Unexpected condition type: ${propertyCondition}`);
         }

--- a/src/db/util/conditions.ts
+++ b/src/db/util/conditions.ts
@@ -260,7 +260,9 @@ export const prepareCondition =
         PropertyConditions.Condition<InstanceData[keyof InstanceData]>
       ][];
       for (const [property, propertyCondition] of propertyConditions) {
-        if (PropertyConditions.isEqualityCondition(propertyCondition)) {
+        if (propertyCondition === undefined) {
+          throw new Error(`Unexpected undefined value for ${property}`);
+        } else if (PropertyConditions.isEqualityCondition(propertyCondition)) {
           builder.where(property, propertyCondition);
         } else if (PropertyConditions.isInCondition(propertyCondition)) {
           builder.whereIn(property, [...propertyCondition[Op.IN]]);

--- a/src/db/util/conditions.ts
+++ b/src/db/util/conditions.ts
@@ -1,0 +1,178 @@
+/* eslint-disable @typescript-eslint/no-namespace */
+// we use namespaces here to neatly organize and scope the many type and type guard definitions
+
+import Knex = require('knex');
+
+/**
+ * Symbols to use for where condition construction
+ */
+namespace ConditionSymbols {
+  export const BUILDER = Symbol('builder');
+  export const AND = Symbol('and');
+  export const OR = Symbol('or');
+
+  /**
+   * Symbols to use for where condition construction
+   */
+  export const Cond = {
+    BUILDER: BUILDER,
+    AND: AND,
+    OR: OR,
+  } as const;
+}
+
+export const Cond = ConditionSymbols.Cond;
+
+/**
+ * Symbols to use when constructing conditions for a single property
+ */
+namespace PropertySymbols {
+  export const IN = Symbol('in');
+  export const NOT_IN = Symbol('not in');
+
+  /**
+   * Symbols to use when constructing conditions for a single property
+   */
+  export const Op = {
+    IN: IN,
+    NOT_IN: NOT_IN,
+  } as const;
+}
+
+export const Op = PropertySymbols.Op;
+
+namespace PropertyConditions {
+  export type EqualityCondition<T> = T;
+  export type InCondition<T> = {
+    [Op.IN]: T[];
+  };
+  export type NotInCondition<T> = {
+    [Op.NOT_IN]: T[];
+  };
+  /**
+   * A condition that must hold over a single property whose type is T
+   */
+  export type Condition<T> =
+    | EqualityCondition<T>
+    | InCondition<T>
+    | NotInCondition<T>;
+
+  export const isEqualityCondition = <T>(
+    condition: Condition<T>
+  ): condition is EqualityCondition<T> =>
+    typeof condition !== 'object' || condition === null;
+
+  export const isInCondition = <T>(
+    condition: Condition<T>
+  ): condition is InCondition<T> =>
+    Object.prototype.hasOwnProperty.call(condition, Op.IN);
+
+  export const isNotInCondition = <T>(
+    condition: Condition<T>
+  ): condition is NotInCondition<T> =>
+    Object.prototype.hasOwnProperty.call(condition, Op.NOT_IN);
+}
+
+namespace OverallConditions {
+  // Overall Condition Definitions
+
+  /**
+   * A collection of conditions across different properties that must all
+   * hold true at the same time
+   */
+  export type PropertyConjunctionCondition<InstanceData> = {
+    [P in keyof InstanceData]?: PropertyConditions.Condition<InstanceData[P]>;
+  };
+
+  export type QueryBuilderCondition<InstanceData> = {
+    [Cond.BUILDER]: Knex.QueryCallback<InstanceData, InstanceData>;
+  };
+
+  export type ConjunctionCondition<InstanceData> = {
+    [Cond.AND]: Array<Condition<InstanceData>>;
+  };
+
+  export type DisjunctionCondition<InstanceData> = {
+    [Cond.OR]: Array<Condition<InstanceData>>;
+  };
+
+  /**
+   * The root type for a custom condition that can be passed to `prepareCondition`
+   * to construct a knex condition / query in a type-safe manner
+   */
+  export type Condition<InstanceData> =
+    | PropertyConjunctionCondition<InstanceData>
+    | QueryBuilderCondition<InstanceData>
+    | ConjunctionCondition<InstanceData>
+    | DisjunctionCondition<InstanceData>;
+
+  export const isQueryBuilderCondition = <T>(
+    condition: Condition<T>
+  ): condition is QueryBuilderCondition<T> =>
+    Object.prototype.hasOwnProperty.call(condition, Cond.BUILDER);
+
+  export const isConjunctionCondition = <T>(
+    condition: Condition<T>
+  ): condition is ConjunctionCondition<T> =>
+    Object.prototype.hasOwnProperty.call(condition, Cond.AND);
+
+  export const isDisjunctionCondition = <T>(
+    condition: Condition<T>
+  ): condition is DisjunctionCondition<T> =>
+    Object.prototype.hasOwnProperty.call(condition, Cond.OR);
+}
+
+/**
+ * The root type for a custom condition that can be passed to `prepareCondition`
+ * to construct a knex condition / query in a type-safe manner
+ */
+export type Condition<InstanceData> = OverallConditions.Condition<InstanceData>;
+
+/**
+ * Given a knex query builder, and one of our own custom conditions,
+ * return the prepared condition to be used directly by knex.
+ *
+ * There are a few reasons we do this rather than simply using knex query
+ * builder directly:
+ *
+ * * the query builder does not offer good type-safety (for example whereIn
+ *   does not require the type of the values to match the type of the column)
+ * * we find ourselves needing to use query builders often for very simple
+ *   conditions that could be abstracted + simplified
+ *
+ * However, we retain the ability to use a query builder when needed.
+ */
+export const prepareCondition =
+  <InstanceData>(
+    condition: Condition<InstanceData>
+  ): Knex.QueryCallback<InstanceData, InstanceData> =>
+  (builder) => {
+    if (OverallConditions.isQueryBuilderCondition(condition)) {
+      builder.where(condition[Cond.BUILDER]);
+    } else if (OverallConditions.isConjunctionCondition(condition)) {
+      for (const c of condition[Cond.AND]) {
+        builder.andWhere(prepareCondition(c));
+      }
+    } else if (OverallConditions.isDisjunctionCondition(condition)) {
+      for (const c of condition[Cond.OR]) {
+        builder.orWhere(prepareCondition(c));
+      }
+    } else {
+      // Combine all property conditions in a single
+      const propertyConditions = Object.entries(condition) as [
+        keyof InstanceData,
+        PropertyConditions.Condition<InstanceData[keyof InstanceData]>
+      ][];
+      for (const [property, propertyCondition] of propertyConditions) {
+        if (PropertyConditions.isEqualityCondition(propertyCondition)) {
+          builder.where(property, propertyCondition);
+        } else if (PropertyConditions.isInCondition(propertyCondition)) {
+          builder.whereIn(property, propertyCondition[Op.IN]);
+        } else if (PropertyConditions.isNotInCondition(propertyCondition)) {
+          builder.whereNotIn(property, propertyCondition[Op.NOT_IN]);
+        } else {
+          throw new Error(`Unexpected condition type: ${propertyCondition}`);
+        }
+      }
+    }
+  };

--- a/src/db/util/id-model.ts
+++ b/src/db/util/id-model.ts
@@ -8,6 +8,7 @@ import {
   InstanceDataOf,
 } from './model-definition';
 import { defineSequelizeModel, FieldsWithSequelize } from './sequelize-model';
+import { Op } from './conditions';
 
 /**
  * Given a definition of fields, and the name of an ID prop,
@@ -97,7 +98,11 @@ export const defineIDModel =
 
     const getAll = async (ids: Iterable<ID>): Promise<Map<ID, Instance>> => {
       const items = await model.find({
-        where: (builder) => builder.whereIn<'id'>('id', [...(ids as any)]),
+        where: {
+          id: {
+            [Op.IN]: ids,
+          },
+        },
       });
       const grouped = new Map<ID, Instance>();
       for (const item of items) {

--- a/src/db/util/versioned-model.ts
+++ b/src/db/util/versioned-model.ts
@@ -1,3 +1,7 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+/**
+ * Use of `any` in this module is generally deliberate to help with generics
+ */
 import Knex = require('knex');
 import merge = require('lodash/merge');
 import * as t from 'io-ts';

--- a/src/db/util/versioned-model.ts
+++ b/src/db/util/versioned-model.ts
@@ -10,6 +10,7 @@ import { ParticipantId, PARTICIPANT_ID } from '../models/participant';
 import { FieldDefinition, UserDataOf } from './model-definition';
 import { defineIDModel } from './id-model';
 import { InstanceDataOfModel, ModelInternals, WhereCond } from './raw-model';
+import { Op } from './conditions';
 
 type LookupColumnDefinition = Pick<FieldDefinition, 'optional' | 'required'>;
 
@@ -247,10 +248,12 @@ export const defineVersionedModel =
         const roots = await rootModel.find(args as any);
         const ids = new Set(roots.map((r) => r.id));
         const versionsList = await versionModel.find({
-          where: (builder) =>
-            builder
-              .whereIn<'root'>('root', [...ids])
-              .andWhere<'isLatest'>('isLatest', true),
+          where: {
+            root: {
+              [Op.IN]: ids,
+            },
+            isLatest: true,
+          },
         });
         const versions = new Map(versionsList.map((v) => [v.root, v]));
 
@@ -296,7 +299,11 @@ export const defineVersionedModel =
       },
       getAll: async (ids) => {
         const items = await result.findAll({
-          where: (builder) => builder.whereIn<'id'>('id', [...(ids as any)]),
+          where: {
+            id: {
+              [Op.IN]: ids as Iterable<any>,
+            },
+          },
         });
         const grouped = new Map<IDType, VersionedInstance<IDType, Data>>();
         for (const item of items) {

--- a/src/lib/data/attachments.ts
+++ b/src/lib/data/attachments.ts
@@ -11,6 +11,7 @@ import { ATTACHMENT_VERSION_VALUE } from '../../db/models/json/attachment';
 import { PlanId } from '../../db/models/plan';
 import { PlanEntityId } from '../../db/models/planEntity';
 import { Database } from '../../db/type';
+import { Op } from '../../db/util/conditions';
 import { InstanceDataOfModel } from '../../db/util/raw-model';
 import {
   AnnotatedMap,
@@ -124,27 +125,34 @@ export const getAllAttachments = async ({
     database.attachmentPrototype,
     (t) =>
       t.find({
-        where: (builder) =>
-          builder.whereIn('type', types).andWhere('planId', planId),
+        where: {
+          planId,
+          type: {
+            [Op.IN]: types,
+          },
+        },
       }),
     'id'
   );
   const attachments = await database.attachment.find({
-    where: (builder) =>
-      builder.whereIn('type', types).andWhere('planId', planId),
+    where: {
+      planId,
+      type: {
+        [Op.IN]: types,
+      },
+    },
   });
   const attachmentVersionsByAttachmentId =
     await findAndOrganizeObjectsByUniqueProperty(
       database.attachmentVersion,
       (t) =>
         t.find({
-          where: (builder) =>
-            builder
-              .whereIn(
-                'attachmentId',
-                attachments.map((pa) => pa.id)
-              )
-              .andWhere('latestVersion', true),
+          where: {
+            latestVersion: true,
+            attachmentId: {
+              [Op.IN]: attachments.map((pa) => pa.id),
+            },
+          },
         }),
       'attachmentId'
     );

--- a/src/lib/data/governingEntities.ts
+++ b/src/lib/data/governingEntities.ts
@@ -3,6 +3,7 @@ import { EntityPrototypeId } from '../../db/models/entityPrototype';
 import { GoverningEntityId } from '../../db/models/governingEntity';
 import { PlanId } from '../../db/models/plan';
 import { Database } from '../../db/type';
+import { Op } from '../../db/util/conditions';
 import { InstanceDataOfModel } from '../../db/util/raw-model';
 import { annotatedMap, AnnotatedMap, getRequiredData } from '../../util';
 
@@ -50,13 +51,12 @@ export const getAllGoverningEntitiesForPlan = async ({
     database.governingEntityVersion,
     (t) =>
       t.find({
-        where: (builder) =>
-          builder
-            .whereIn(
-              'governingEntityId',
-              ges.map((ge) => ge.id)
-            )
-            .andWhere('latestVersion', true),
+        where: {
+          latestVersion: true,
+          governingEntityId: {
+            [Op.IN]: ges.map((ge) => ge.id),
+          },
+        },
       }),
     'governingEntityId'
   );

--- a/src/lib/data/planEntities.ts
+++ b/src/lib/data/planEntities.ts
@@ -4,6 +4,7 @@ import { GoverningEntityId } from '../../db/models/governingEntity';
 import { PlanId } from '../../db/models/plan';
 import { PlanEntityId } from '../../db/models/planEntity';
 import { Database } from '../../db/type';
+import { Op } from '../../db/util/conditions';
 import { InstanceDataOfModel } from '../../db/util/raw-model';
 import {
   isDefined,
@@ -72,10 +73,12 @@ export const getAndValidateAllPlanEntities = async ({
     database.planEntityVersion,
     (t) =>
       t.find({
-        where: (builder) =>
-          builder
-            .whereIn('planEntityId', [...planEntityIDs])
-            .andWhere('latestVersion', true),
+        where: {
+          latestVersion: true,
+          planEntityId: {
+            [Op.IN]: planEntityIDs,
+          },
+        },
       }),
     'planEntityId'
   );
@@ -84,11 +87,13 @@ export const getAndValidateAllPlanEntities = async ({
     database.entitiesAssociation,
     (t) =>
       t.find({
-        where: (builder) =>
-          builder
-            .whereIn('childId', [...planEntityIDs])
-            .andWhere('parentType', 'governingEntity')
-            .andWhere('childType', 'planEntity'),
+        where: {
+          childType: 'planEntity',
+          parentType: 'governingEntity',
+          childId: {
+            [Op.IN]: planEntityIDs,
+          },
+        },
       }),
     'childId'
   );

--- a/src/lib/data/projects.ts
+++ b/src/lib/data/projects.ts
@@ -6,6 +6,7 @@ import { ProjectId } from '../../db/models/project';
 import { Database } from '../../db/type';
 import { InstanceOfModel } from '../../db/util/types';
 import { getRequiredData, groupObjectsByProperty, isDefined } from '../../util';
+import { Op } from '../../db/util/conditions';
 
 export interface ProjectData {
   project: InstanceOfModel<Database['project']>;
@@ -37,31 +38,33 @@ export async function getAllProjectsForPlan({
     database.projectVersion,
     (t) =>
       t.find({
-        where: (builder) =>
-          builder.whereIn('id', [
-            ...new Set(pvps.map((pvp) => pvp.projectVersionId)),
-          ]),
+        where: {
+          id: {
+            [Op.IN]: new Set(pvps.map((pvp) => pvp.projectVersionId)),
+          },
+        },
       }),
     'id'
   );
   const projectVersions = [...pvsById.values()];
   const projects = await database.project.find({
-    where: (builder) =>
-      builder.whereIn('id', [
-        ...new Set(projectVersions.map((pv) => pv.projectId)),
-      ]),
+    where: {
+      id: {
+        [Op.IN]: new Set(projectVersions.map((pv) => pv.projectId)),
+      },
+    },
   });
   const workflowStatusById = await findAndOrganizeObjectsByUniqueProperty(
     database.workflowStatusOption,
     (t) =>
       t.find({
-        where: (builder) =>
-          builder.whereIn(
-            'id',
-            [...new Set(pvps.map((pvp) => pvp.workflowStatusOptionId))].filter(
-              isDefined
-            )
-          ),
+        where: {
+          id: {
+            [Op.IN]: [
+              ...new Set(pvps.map((pvp) => pvp.workflowStatusOptionId)),
+            ].filter(isDefined),
+          },
+        },
       }),
     'id'
   );
@@ -117,8 +120,11 @@ export async function getOrganizationIDsForProjects({
 
   const groupedPVOs = groupObjectsByProperty(
     await database.projectVersionOrganization.find({
-      where: (builder) =>
-        builder.whereIn('projectVersionId', projectVersionIds),
+      where: {
+        projectVersionId: {
+          [Op.IN]: projectVersionIds,
+        },
+      },
     }),
     'projectVersionId'
   );
@@ -148,8 +154,11 @@ export async function getGoverningEntityIDsForProjects({
 
   const groupedPVGEs = groupObjectsByProperty(
     await database.projectVersionGoverningEntity.find({
-      where: (builder) =>
-        builder.whereIn('projectVersionId', projectVersionIds),
+      where: {
+        projectVersionId: {
+          [Op.IN]: projectVersionIds,
+        },
+      },
     }),
     'projectVersionId'
   );


### PR DESCRIPTION
As discussed earlier today, this PR introduces a new abstraction over where conditions (with support for nested conjunctions (AND) and disjunctions (OR)), to allow for better type-safety with data used for constructing queries, and to make our most common use-cases easier to write.

The queries generated by this are unit-tested in hpc_service: UN-OCHA/hpc_service#2529. (This is needed until #26 is merged)

This PR makes use of query builders in the where clauses type errors, using query builders in conditions is still possible, but now requires us to explicitly use `[Cond.BUILDER]`. This should help us catch and rewrite all instances of usage of the old builder when not neccesary.

(this will cause type-error conflict with #57, so whichever is merged last will need to be rebased and fixed)