### PR TITLE
Fix category group type

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@unocha/hpc-api-core",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Core libraries supporting HPC.Tools API Backend",
   "license": "Apache-2.0",
   "private": false,

--- a/src/db/models/category.ts
+++ b/src/db/models/category.ts
@@ -21,7 +21,7 @@ export default defineIDModel({
     },
     required: {
       name: { kind: 'checked', type: t.string },
-      group: { kind: 'branded-integer', brand: CATEGORY_GROUP_TYPE },
+      group: { kind: 'checked', type: CATEGORY_GROUP_TYPE },
     },
     optional: {
       description: { kind: 'checked', type: t.string },


### PR DESCRIPTION
This column was wrongly defined as branded integer because it is a foreign key, but it is obviously not numerical ID foreign key, but textual one.