### PR TITLE
Don't throw an error if empty array is passed to `createMany`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@unocha/hpc-api-core",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Core libraries supporting HPC.Tools API Backend",
   "license": "Apache-2.0",
   "private": false,

--- a/src/db/util/raw-model.ts
+++ b/src/db/util/raw-model.ts
@@ -119,6 +119,10 @@ export const defineRawModel =
     };
 
     const createMany: CreateManyFn<F> = async (data, opts) => {
+      if (!data.length) {
+        return [];
+      }
+
       const builder = opts?.trx ? tbl().transacting(opts.trx) : tbl();
       const res = await builder.insert(data).returning('*');
       return res.map(validateAndFilter);


### PR DESCRIPTION
If empty array is provided to `createMany`, `knex` doesn't mind executing the query (even though it does nothing), but `res.map(validateAndFilter)` fails since returned result is an object, rather than array of created rows.