### PR TITLE
Further changes to support HPC-8149

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@unocha/hpc-api-core",
-  "version": "1.1.4",
+  "version": "1.2.0",
   "description": "Core libraries supporting HPC.Tools API Backend",
   "license": "Apache-2.0",
   "private": false,


### PR DESCRIPTION
This PR should be the last of these for this repo,

A couple of library functions have been adjusted to be a bit permissive of inconsistent data due to the nature of the data being analysed. This comes from testing the new functionality on all 2021 plans. After these changes, all plans successfully return data for gap analysis.