### PR TITLE
HPC-8479: Add strict codec for disaggregation model value

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@unocha/hpc-api-core",
-  "version": "4.2.0",
+  "version": "4.2.1",
   "description": "Core libraries supporting HPC.Tools API Backend",
   "license": "Apache-2.0",
   "private": false,

--- a/src/db/models/disaggregationModel.ts
+++ b/src/db/models/disaggregationModel.ts
@@ -18,11 +18,6 @@ export const DISAGGREGATION_MODEL_ID = brandedType<
   DisaggregationModelId
 >(t.number);
 
-export const DISAGGREGATION_MODEL_CREATOR = t.type({
-  participantHidId: t.string,
-  roles: t.array(t.string),
-});
-
 const LOCATION_INFO = t.intersection([
   t.type({ name: t.string }),
   t.partial({

--- a/src/db/models/disaggregationModel.ts
+++ b/src/db/models/disaggregationModel.ts
@@ -31,6 +31,16 @@ const LOCATION_INFO = t.intersection([
   }),
 ]);
 
+/**
+ * Strict version of `LOCATION_INFO` codec defined above.
+ * Intended to be used when creating new records, in order
+ * to enforce stricter type of location ID.
+ */
+const LOCATION_INFO_STRICT = t.intersection([
+  LOCATION_INFO.types[0],
+  t.partial({ id: LOCATION_ID }),
+]);
+
 export const DISAGGREGATION_MODEL_VALUE = t.type({
   categories: t.array(
     t.type({
@@ -43,6 +53,26 @@ export const DISAGGREGATION_MODEL_VALUE = t.type({
     t.intersection([LOCATION_INFO, t.partial({ parent: LOCATION_INFO })])
   ),
   status: t.boolean,
+});
+
+/**
+ * Strict version of `DISAGGREGATION_MODEL_VALUE` codec defined above.
+ * Intended to be used when creating new records, in order to enforce
+ * stricter type of location ID.
+ *
+ * Location ID used to allow for string type, which is why there are
+ * many records using location's pcode instead of ID. This stricter
+ * type should be used for validating new records upon creation.
+ */
+export const DISAGGREGATION_MODEL_VALUE_STRICT = t.type({
+  categories: DISAGGREGATION_MODEL_VALUE.props.categories,
+  status: DISAGGREGATION_MODEL_VALUE.props.status,
+  locations: t.array(
+    t.intersection([
+      LOCATION_INFO_STRICT,
+      t.partial({ parent: LOCATION_INFO_STRICT }),
+    ])
+  ),
 });
 
 export default defineIDModel({


### PR DESCRIPTION
Strict version of `DISAGGREGATION_MODEL_VALUE` codec is added, where location IDs not being numeric is not tolerated. This strict codec should be used to validate new disaggregation models being created.