### PR TITLE
Search participants by `hidSub` directly from DB

### DIFF
--- a/src/auth/index.ts
+++ b/src/auth/index.ts
@@ -136,11 +136,9 @@ export const getLoggedInParticipant = async (
     return undefined;
   }
 
-  const participants = await models.participant.find({
+  let participant = await models.participant.findOne({
     where: { hidSub: hidInfo.sub },
   });
-  let participant =
-    participants.find((p) => p.hidSub === hidInfo.sub) || undefined;
 
   if (!participant) {
     // Create a new participant for this HID account


### PR DESCRIPTION
We currenly search the `participant` table by `hidSub` column, expecting 0 or many results. Then, `Array.prototype.filter()` is applied on the results, effectively applying the same condition by which we queried the DB, so we get the first participant with a given `hidSub` back.

This overhead is not necessary, since `hidSub` is an unique column (has `UNIQUE INDEX`). This code is a leftover from days when `hidId` and `hidSub` coexisted in `participant` table and were both used for querying, where one got the precedence over the other - [UN-OCHA/hpc_service@`da4256a`](https://github.com/UN-OCHA/hpc_service/commit/da4256a340847495237e280cf2f5a72bba3aaca7#diff-00edcb7cb402610ed7c96acfc98b4f1847866ecad3f56816d26bc73f339d2469R217)

We switched to querying `hidSub` exclusively in [UN-OCHA/hpc_service@`a8e027f`](https://github.com/UN-OCHA/hpc_service/commit/a8e027f8e6b01e1af7b71befb4a84f5b4be40b61#diff-00edcb7cb402610ed7c96acfc98b4f1847866ecad3f56816d26bc73f339d2469R208), but this pattern of using `Array.prototype.filter()` persisted.