### PR TITLE
Add `skipValidation` support to `find` and `update` methods

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@unocha/hpc-api-core",
-  "version": "4.4.3",
+  "version": "4.4.4",
   "description": "Core libraries supporting HPC.Tools API Backend",
   "license": "Apache-2.0",
   "private": false,

--- a/src/db/util/raw-model.ts
+++ b/src/db/util/raw-model.ts
@@ -39,6 +39,11 @@ export type FindFn<F extends FieldDefinition, AdditionalArgs = {}> = (
     limit?: number;
     offset?: number;
     orderBy?: OrderByCond<F> | Array<OrderByCond<F>>;
+    /**
+     * WARNING: Only use this in very rare cases when performance gains
+     * from disabling validation are worth the risk!
+     */
+    skipValidation?: boolean;
     trx?: Knex.Transaction<any, any>;
   } & AdditionalArgs
 ) => Promise<Array<InstanceDataOf<F>>>;
@@ -138,6 +143,7 @@ export const defineRawModel =
       limit,
       offset,
       orderBy,
+      skipValidation = false,
       trx,
     } = {}) => {
       const builder = trx ? tbl().transacting(trx) : tbl();
@@ -159,6 +165,11 @@ export const defineRawModel =
       }
 
       const res = await query;
+
+      if (skipValidation) {
+        return res as Instance[];
+      }
+
       return res.map(validateAndFilter);
     };
 


### PR DESCRIPTION
This is to support https://github.com/UN-OCHA/hpc-api/pull/94

This PR adds `skipValidation` option for `find` and `update` methods of our models. This feature skips data validation that we do with our `io-ts` codecs. It should be used very rarely!

We've seen some endpoints suffer from significant slowdowns (like in https://github.com/UN-OCHA/hpc-api/pull/94) due to data validation and it takes a significant portion of time to complete the query. For example, when fetching attachments by their IDs, data fetching takes 20-25% of time, while validation takes 75-80% of time, which can be a huge burden, causing timeouts of our APIs.