### PR TITLE
Exit shortly if permission condition is `'noone'`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@unocha/hpc-api-core",
-  "version": "4.4.4",
+  "version": "4.5.0",
   "description": "Core libraries supporting HPC.Tools API Backend",
   "license": "Apache-2.0",
   "private": false,

--- a/src/auth/index.ts
+++ b/src/auth/index.ts
@@ -191,6 +191,10 @@ export const actionIsPermitted = async <
     return true;
   }
 
+  if (condition === 'noone') {
+    return false;
+  }
+
   return hasRequiredPermissions(await calculatePermissions(context), condition);
 };
 


### PR DESCRIPTION
The outcome will be the same, action will not be permitted anyway, but we save some time here, not calculating permissions when inevitable will happen - access will be denied.