### PR TITLE
HPC-8565: Expand project deletion permissions and grants

### DIFF
--- a/src/auth/permissions.ts
+++ b/src/auth/permissions.ts
@@ -154,6 +154,10 @@ export const AUTH_PERMISSIONS = {
     MODIFY_ACCESS_AND_PERMISSIONS_OF_PROJECTS:
       'canModifyAccessAndPermissionsOfProjects',
     /**
+     * Can delete any project under this plan
+     */
+    DELETE_PROJECTS: 'deleteProjects',
+    /**
      * Can clone any project under this plan
      */
     CLONE_PROJECTS: 'cloneProjects',

--- a/src/auth/roles.ts
+++ b/src/auth/roles.ts
@@ -290,6 +290,7 @@ export const calculatePermissionsFromRolesGrant = async <
     for (const role of grant.roles) {
       if (role === 'projectOwner') {
         projectSet.add(P.project.CLONE);
+        projectSet.add(P.project.DELETE);
         projectSet.add(P.project.MODIFY_ACCESS_AND_PERMISSIONS);
         projectSet.add(P.project.VIEW_DATA);
       }

--- a/src/auth/roles.ts
+++ b/src/auth/roles.ts
@@ -275,6 +275,7 @@ export const calculatePermissionsFromRolesGrant = async <
         planSet.add(P.plan.VIEW_DATA);
         planSet.add(P.plan.EDIT_DATA);
         planSet.add(P.plan.MODIFY_ACCESS_AND_PERMISSIONS_OF_PROJECTS);
+        planSet.add(P.plan.DELETE_PROJECTS);
         planSet.add(P.plan.CLONE_PROJECTS);
         planSet.add(P.plan.MAKE_VISIBLE_IN_PROJECTS);
       }


### PR DESCRIPTION
The goal of [HPC-8565](https://humanitarian.atlassian.net/browse/HPC-8565) is to allow project owners and plan leads to delete projects. Therefore, add existing `project.DELETE` permission to project owners and introduce `plan.DELETE_PROJECTS` permission and grant it to plan leads.