### PR TITLE
HPC-8748: Introduce project deleting util method

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@unocha/hpc-api-core",
-  "version": "8.0.0",
+  "version": "8.1.0",
   "description": "Core libraries supporting HPC.Tools API Backend",
   "license": "Apache-2.0",
   "private": false,

--- a/src/db/deletion/project.ts
+++ b/src/db/deletion/project.ts
@@ -1,0 +1,99 @@
+import Knex = require('knex');
+import type { Database } from '..';
+import { deleteAuthTarget } from '../../auth';
+import { NotFoundError, PreconditionFailedError } from '../../util/error';
+import type { ParticipantId } from '../models/participant';
+import type { ProjectId } from '../models/project';
+
+export const deleteProjectById = async (
+  database: Database,
+  projectToDelete: ProjectId,
+  authGrantRevoker: ParticipantId,
+  trx: Knex.Transaction<any, any>
+) => {
+  const project = await database.project.findOne({
+    where: { id: projectToDelete },
+    trx,
+  });
+
+  if (!project) {
+    throw new NotFoundError(`No project with ID ${projectToDelete}`);
+  }
+
+  // Cannot delete already published project
+  if (project.currentPublishedVersionId) {
+    throw new PreconditionFailedError(
+      `Project with ID ${project.id} has already been published`
+    );
+  }
+
+  if (project.latestVersionId) {
+    const latestVersion = await database.projectVersion.findOne({
+      where: { id: project.latestVersionId },
+      trx,
+    });
+
+    if (latestVersion?.version !== 1) {
+      throw new PreconditionFailedError(
+        `More than one version of project with ID ${project.id} has been created`
+      );
+    }
+  }
+
+  const linkedToFlows = await database.flowObject.find({
+    where: {
+      objectType: 'project',
+      objectID: project.id,
+    },
+    trx,
+  });
+  const totalLinkedFlows = linkedToFlows.length;
+
+  if (totalLinkedFlows) {
+    throw new PreconditionFailedError(
+      `Cannot delete project because it is linked to flows with ID: ${linkedToFlows
+        .map((f) => f.flowID)
+        .slice(0, 10)
+        .join(', ')}.${
+        totalLinkedFlows > 10
+          ? ` There are ${
+              totalLinkedFlows - 10
+            } more flows, we're just showing the first 10`
+          : ''
+      }`
+    );
+  }
+
+  const clonedProjects = await database.project.find({
+    where: { sourceProjectId: project.id },
+    trx,
+  });
+
+  // Unlink all cloned projects
+  await database.project.update({
+    values: { sourceProjectId: null },
+    where: {
+      id: { [database.Op.IN]: clonedProjects.map((p) => p.id) },
+    },
+    trx,
+  });
+
+  await database.project.destroy({
+    where: { id: project.id },
+    trx,
+  });
+
+  // Delete weak references
+  await database.expiredData.destroy({
+    where: { objectType: 'project', objectId: project.id },
+    trx,
+  });
+
+  // Clean up all references in auth tables
+  await deleteAuthTarget(
+    database,
+    { type: 'project', targetId: projectToDelete },
+    authGrantRevoker,
+    trx
+  );
+};


### PR DESCRIPTION
With this PR, we're starting work on properly cleaning up related data upon deletion - [HPC-8748](https://humanitarian.atlassian.net/browse/HPC-8748). I was thinking of introducing a generic method wrapper for DB models, which would allow you to specify all tables with weak references to that model (table). I am using term "weak references" for tables which have `objectId`-`objectType` columns, which can have pointers to entities in other tables, without actual foreign keys. I have abandoned idea of a generic method for related data cleanup, because DB models would have to have reference outside tables, which goes against the separation of concerns and encapsulation.

Thus, I am introducing deletion utility methods. They will give us much more flexibility about setting deletion conditions and cleanup rules for each different table. The downside is that we need to remember to call the util method and not just `model.destroy()` on some tables.

To kickstart this idea of cleaning up properly after deletion, I have added utility method to delete a project and clean up afterwards. Along with that, I have added the possibility to delete just the latest version of the project - [HPC-8746](https://humanitarian.atlassian.net/browse/HPC-8746). We can already see that having utility method, rather than putting the logic into `project.destroy()` has advantages in allowing arbitrary complexity in logic.

Regarding project deletion, tables `project` and `projectVersion` have weak references in other tables:
- `projectVersion`:
  - `categoryRef`
- `project`:
  - `budgetSegmentBreakdownEntity`
  - `flowObject`
  - `expiredData` (table is still not used, but we should clean it up anyway)
  - `authTarget`

Table `budgetSegmentBreakdownEntity` has some records where `objectType` is "projectVersion". However, `objectId` values in these cases are actually pointing to project ID, not project version ID! Since this table is actually connected to **project version** by series of foreign keys, that means that deleting **project** also deletes `budgetSegmentBreakdownEntity`. That series of foreign keys is `project`->`projectVersion`->`budgetSegment`->`budgetSegmentBreakdown`->`budgetSegmentBreakdownEntity`

[HPC-8748]: https://humanitarian.atlassian.net/browse/HPC-8748?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[HPC-8746]: https://humanitarian.atlassian.net/browse/HPC-8746?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ