### PR TITLE
Allow to specify flow ID when inserting new rows

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@unocha/hpc-api-core",
-  "version": "6.0.0",
+  "version": "6.1.0",
   "description": "Core libraries supporting HPC.Tools API Backend",
   "license": "Apache-2.0",
   "private": false,

--- a/src/db/models/flow.ts
+++ b/src/db/models/flow.ts
@@ -12,7 +12,7 @@ export const FLOW_ID = brandedType<number, FlowId>(t.number);
 export default defineIDModel({
   tableName: 'flow',
   fields: {
-    generated: {
+    generatedCompositeKey: {
       id: { kind: 'branded-integer', brand: FLOW_ID },
     },
     required: {

--- a/src/db/util/id-model.ts
+++ b/src/db/util/id-model.ts
@@ -68,7 +68,8 @@ export type { FieldsWithSequelize as FieldsWithId };
 export const defineIDModel =
   <
     F extends FieldDefinition,
-    IDField extends string & keyof F['generated'],
+    IDField extends string &
+      (keyof F['generated'] | keyof F['generatedCompositeKey']),
     SoftDeletionEnabled extends boolean
   >(opts: {
     tableName: string;

--- a/src/db/util/model-definition.ts
+++ b/src/db/util/model-definition.ts
@@ -52,6 +52,12 @@ export type FieldDefinition = {
    * such ids that use autoIncrement.
    */
   generated?: FieldSet;
+  /**
+   * Same as `generated`, but indicates that auto-incremented ID is used as
+   * part of a composite primary key on the table, thus we need to make it
+   * possible for client code to specify these IDs when inserting new rows.
+   */
+  generatedCompositeKey?: FieldSet;
   nonNullWithDefault?: FieldSet;
   optional?: FieldSet;
   accidentallyOptional?: FieldSet;
@@ -68,14 +74,16 @@ export type FieldValuesOfSet<Set extends FieldSet | undefined> =
 export type InstanceDataOf<F extends FieldDefinition> = FieldValuesOfSet<
   F['generated']
 > &
+  FieldValuesOfSet<F['generatedCompositeKey']> &
   FieldValuesOfSet<F['nonNullWithDefault']> &
   FieldValuesOfSet<F['required']> &
   Nullable<FieldValuesOfSet<F['optional']>> &
   Nullable<FieldValuesOfSet<F['accidentallyOptional']>>;
 
 export type UserDataOf<F extends FieldDefinition> = Partial<
-  FieldValuesOfSet<F['nonNullWithDefault']>
+  FieldValuesOfSet<F['generatedCompositeKey']>
 > &
+  Partial<FieldValuesOfSet<F['nonNullWithDefault']>> &
   FieldValuesOfSet<F['required']> &
   FieldValuesOfSet<F['accidentallyOptional']> &
   Partial<Nullable<FieldValuesOfSet<F['optional']>>>;


### PR DESCRIPTION
DB table `flow` is the only table we have where its `id` column is part of a composite key, alongside `versionID` column. Since we weren't allowing for specifying IDs during new row insertion, it wasn't possible to create a new version of already-existing flow with the database models library.

We don't want to allow all tables to specify IDs when inserting new flows, thus we introduce a new field definition group called `generatedCompositeKey`, which is among the least intrusive and least hacky ways of achieving the desired outcome.