### PR TITLE
Allow `generatedCompositeKey` everywhere `generated` is needed 

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@unocha/hpc-api-core",
-  "version": "6.1.0",
+  "version": "6.1.1",
   "description": "Core libraries supporting HPC.Tools API Backend",
   "license": "Apache-2.0",
   "private": false,

--- a/src/db/util/id-model.ts
+++ b/src/db/util/id-model.ts
@@ -26,6 +26,10 @@ type IdOf<
       [K in IDField]: Field;
     }
     ? FieldTypeOf<F['generated'][IDField]>
+    : F['generatedCompositeKey'] extends {
+        [K in IDField]: Field;
+      }
+    ? FieldTypeOf<F['generatedCompositeKey'][IDField]>
     : never
   : never;
 
@@ -35,7 +39,7 @@ type IdOf<
  */
 export interface ModelWithId<
   F extends FieldDefinition,
-  IDField extends null | keyof F['generated']
+  IDField extends null | keyof F['generated'] | keyof F['generatedCompositeKey']
 > extends Model<F, AdditionalFindArgsForSequelizeTables> {
   readonly get: (id: IdOf<F, IDField>) => Promise<null | InstanceDataOf<F>>;
   readonly getAll: (
@@ -48,7 +52,7 @@ export interface ModelWithId<
  */
 export type ModelWithIdInitializer<
   F extends FieldDefinition,
-  IDField extends null | keyof F['generated']
+  IDField extends null | keyof F['generated'] | keyof F['generatedCompositeKey']
 > = (conn: Knex) => ModelWithId<F, IDField>;
 
 const hasField = <F extends string>(

--- a/src/db/util/legacy-versioned-model.ts
+++ b/src/db/util/legacy-versioned-model.ts
@@ -44,7 +44,8 @@ export type FieldsWithVersioned<
  */
 export const defineLegacyVersionedModel = <
   F extends FieldDefinition,
-  IDField extends string & keyof F['generated'],
+  IDField extends string &
+    (keyof F['generated'] | keyof F['generatedCompositeKey']),
   SoftDeletionEnabled extends boolean
 >(opts: {
   tableName: string;

--- a/src/db/util/validation.ts
+++ b/src/db/util/validation.ts
@@ -140,7 +140,10 @@ export const dataValidator = <F extends FieldDefinition>(
   };
 
   const instanceValidator = t.intersection([
-    fieldSetValidator(fields.generated || {}, false),
+    t.intersection([
+      fieldSetValidator(fields.generated || {}, false),
+      fieldSetValidator(fields.generatedCompositeKey || {}, false),
+    ]),
     fieldSetValidator(fields.nonNullWithDefault || {}, false),
     fieldSetValidator(fields.required || {}, false),
     fieldSetValidator(fields.optional || {}, true),


### PR DESCRIPTION
Fixes shortcomings of #125, where we missed adding `generatedCompositeKey` to the list of fields [where io-ts codecs for validation are drawn from](https://github.com/UN-OCHA/hpc-api-core/blob/843cef50582aa5272a68b84094441e2be5824004/src/db/util/validation.ts#L143). So, now, we fix the problem and also allow `generatedCompositeKey` everywhere `generated` is allowed.