### PR TITLE
Add a bunch of utility methods supporting work on HPC-9193

### DIFF
--- a/src/lib/data/locations.ts
+++ b/src/lib/data/locations.ts
@@ -1,5 +1,9 @@
 import type { Database } from '../../db';
+import type { LocationId } from '../../db/models/location';
 import type { PlanId } from '../../db/models/plan';
+import type { InstanceOfModel } from '../../db/util/types';
+import { getOrCreate } from '../../util';
+import { NotFoundError } from '../../util/error';
 
 export const getPlanCountries = async (
   database: Database,
@@ -23,4 +27,56 @@ export const getPlanCountries = async (
       parentId: { [database.Op.IS_NULL]: true },
     },
   });
+};
+
+export const getAllCountryLocations = async (
+  database: Database,
+  countryId: LocationId
+): Promise<Map<number, InstanceOfModel<Database['location']>[]>> => {
+  const country = await database.location.findOne({
+    where: {
+      id: countryId,
+      adminLevel: 0,
+      status: 'active',
+      parentId: { [database.Op.IS_NULL]: true },
+    },
+  });
+
+  if (!country) {
+    throw new NotFoundError(
+      `No country with ID ${countryId}. ` +
+        `Make sure location with ID ${countryId} is an active country (i.e. admin 0 location)`
+    );
+  }
+
+  let previousAdminLevelIds = [country.id];
+  let nextAdminLevel = 1;
+  const countryLocationsByAdminLevel = new Map<
+    number,
+    Array<InstanceOfModel<Database['location']>>
+  >([[0, [country]]]);
+
+  while (previousAdminLevelIds.length) {
+    const locations = await database.location.find({
+      where: {
+        parentId: { [database.Op.IN]: previousAdminLevelIds },
+        adminLevel: nextAdminLevel,
+        status: 'active',
+      },
+    });
+
+    for (const location of locations) {
+      const countriesInAdminLevel = getOrCreate(
+        countryLocationsByAdminLevel,
+        nextAdminLevel,
+        () => []
+      );
+      countriesInAdminLevel.push(location);
+    }
+
+    previousAdminLevelIds = locations.map((l) => l.id);
+    nextAdminLevel++;
+  }
+
+  return countryLocationsByAdminLevel;
 };

--- a/src/lib/data/locations.ts
+++ b/src/lib/data/locations.ts
@@ -1,0 +1,26 @@
+import type { Database } from '../../db';
+import type { PlanId } from '../../db/models/plan';
+
+export const getPlanCountries = async (
+  database: Database,
+  planId: PlanId,
+  version: 'current' | 'latest'
+) => {
+  const planLocations = await database.planLocation.find({
+    where: {
+      planId,
+      ...(version === 'latest'
+        ? { latestVersion: true }
+        : { currentVersion: true }),
+    },
+  });
+
+  return database.location.find({
+    where: {
+      id: { [database.Op.IN]: planLocations.map((pl) => pl.locationId) },
+      adminLevel: 0,
+      status: 'active',
+      parentId: { [database.Op.IS_NULL]: true },
+    },
+  });
+};

--- a/src/lib/data/organizations.ts
+++ b/src/lib/data/organizations.ts
@@ -1,0 +1,85 @@
+import type { Database } from '../../db';
+import type { OrganizationId } from '../../db/models/organization';
+import type { InstanceDataOfModel } from '../../db/util/raw-model';
+import {
+  groupObjectsByProperty,
+  organizeObjectsByUniqueProperty,
+} from '../../util';
+
+type OrganizationInfo = InstanceDataOfModel<Database['organization']> & {
+  type: string;
+  subType: string;
+  level: string;
+};
+
+/**
+ * Fetches organizations with requested IDs,
+ * plus their type, subtype and level
+ */
+export const getOrganizationsInfo = async (
+  database: Database,
+  organizationIds: Iterable<OrganizationId>
+): Promise<OrganizationInfo[]> => {
+  const organizations = await database.organization.find({
+    where: {
+      id: { [database.Op.IN]: organizationIds },
+      active: true,
+    },
+  });
+
+  const categoriesByOrganizationId = groupObjectsByProperty(
+    await database.categoryRef.find({
+      where: {
+        objectType: 'organization',
+        objectID: { [database.Op.IN]: organizations.map((o) => o.id) },
+      },
+    }),
+    'objectID'
+  );
+
+  const categoriesById = organizeObjectsByUniqueProperty(
+    await database.category.find({
+      where: {
+        id: {
+          [database.Op.IN]: [...categoriesByOrganizationId.values()]
+            .flatMap((crSet) => [...crSet])
+            .map((cr) => cr.categoryID),
+        },
+        group: { [database.Op.IN]: ['organizationType', 'organizationLevel'] },
+      },
+    }),
+    'id'
+  );
+
+  return organizations.map((o) => {
+    const organizationCategories = categoriesByOrganizationId.get(o.id);
+
+    let type = '';
+    let subType = '';
+    let level = '';
+
+    for (const organizationCategory of organizationCategories ?? []) {
+      const category = categoriesById.get(organizationCategory.categoryID);
+
+      if (category?.group === 'organizationType') {
+        if (category.parentID) {
+          subType = category.name;
+        } else {
+          type = category.name;
+        }
+      } else if (
+        category?.group === 'organizationLevel' &&
+        !category.parentID
+      ) {
+        level = category.name;
+      }
+    }
+
+    return {
+      ...o,
+      type,
+      subType,
+      level,
+    };
+  });
+};

--- a/src/lib/data/projects.ts
+++ b/src/lib/data/projects.ts
@@ -10,7 +10,7 @@ import { Op } from '../../db/util/conditions';
 import { GlobalClusterId } from '../../db/models/globalCluster';
 import { createBrandedValue } from '../../util/types';
 import { SharedLogContext } from '../logging';
-import { isEqual } from 'lodash';
+import isEqual = require('lodash/isEqual');
 
 /**
  * The `name` value used across all budget segments that are segmented by

--- a/src/lib/data/usageYears.ts
+++ b/src/lib/data/usageYears.ts
@@ -1,0 +1,30 @@
+import type { Database } from '../../db';
+import type { PlanId } from '../../db/models/plan';
+import { NotFoundError } from '../../util/error';
+
+export const getPlanYears = async (
+  database: Database,
+  planId: PlanId,
+  version: 'current' | 'latest'
+) => {
+  const planYears = await database.planYear.find({
+    where: {
+      planId,
+      ...(version === 'latest'
+        ? { latestVersion: true }
+        : { currentVersion: true }),
+    },
+  });
+
+  if (planYears.length === 0) {
+    throw new NotFoundError(
+      `Plan with ID ${planId} doesn't have an associated year`
+    );
+  }
+
+  const usageYears = await database.usageYear.getAll(
+    planYears.map((p) => p.usageYearId)
+  );
+
+  return [...usageYears.values()].map((uy) => uy.year);
+};

--- a/src/util/index.ts
+++ b/src/util/index.ts
@@ -279,3 +279,22 @@ export const cleanNumberVal = (value: number | string | null): number | null =>
     : typeof value === 'string' && value !== ''
     ? parseFloat(value.trim().replace(/,/g, ''))
     : null;
+
+export const toCamelCase = (originalString: string) => {
+  let isNextLetterUppercase = false;
+  let convertedString = '';
+
+  for (const char of originalString) {
+    if (char === ' ') {
+      isNextLetterUppercase = true;
+      continue;
+    }
+
+    convertedString += isNextLetterUppercase
+      ? char.toUpperCase()
+      : char.toLowerCase();
+    isNextLetterUppercase = false;
+  }
+
+  return convertedString;
+};

--- a/src/util/index.ts
+++ b/src/util/index.ts
@@ -272,3 +272,10 @@ export const getRequiredDataByValue = <K, V, E>(
   }
   return val;
 };
+
+export const cleanNumberVal = (value: number | string | null): number | null =>
+  typeof value === 'number'
+    ? value
+    : typeof value === 'string' && value !== ''
+    ? parseFloat(value.trim().replace(/,/g, ''))
+    : null;


### PR DESCRIPTION
Introduced utility methods to get:
- Years of a plan
- Basic organization info plus their type, subtype and level
- Attachment and measurement disaggregation data
- All country locations

Also, some non-fetching utility methods were added to:
- Convert string to camel case
- Clean numeric values; `cleanNumberVal` got moved here from hpc_service