### PR TITLE
HPC-9280: Support for plan deletion

### DIFF
--- a/src/auth/index.ts
+++ b/src/auth/index.ts
@@ -4,7 +4,6 @@
  */
 import * as crypto from 'node:crypto';
 import { promisify } from 'node:util';
-import type v4Models from '../db';
 import { type AuthTargetId } from '../db/models/authTarget';
 import { type ParticipantId } from '../db/models/participant';
 import type { Database } from '../db/type';
@@ -30,8 +29,6 @@ import {
 } from './roles';
 
 const randomBytes = promisify(crypto.randomBytes);
-
-type Models = ReturnType<typeof v4Models>;
 
 type Participant = InstanceOfModel<Database['participant']>;
 type AuthGrantee = InstanceOfModel<Database['authGrantee']>;
@@ -471,11 +468,11 @@ export const getParticipantFromToken = async (
 export const createToken = async ({
   participant,
   expires,
-  models,
+  database,
 }: {
   participant: ParticipantId;
   expires?: Date;
-  models: Models;
+  database: Database;
 }): Promise<{
   instance: AuthToken;
   token: string;
@@ -487,7 +484,7 @@ export const createToken = async ({
     .digest()
     .toString('hex');
   return {
-    instance: await models.authToken.create({
+    instance: await database.authToken.create({
       tokenHash,
       participant,
       expires,

--- a/src/auth/permissions.ts
+++ b/src/auth/permissions.ts
@@ -85,6 +85,7 @@ export const AUTH_PERMISSIONS = {
      */
     CLONE_ANY_PROJECT: 'cloneAnyProject',
     DELETE_ANY_PROJECT: 'canDeleteAnyProject',
+    DELETE_ANY_PLAN: 'canDeleteAnyPlan',
     /**
      * Can change visibility of any plan in Projects Module
      */

--- a/src/auth/roles.ts
+++ b/src/auth/roles.ts
@@ -181,6 +181,7 @@ export const calculatePermissionsFromRolesGrant = async <
         global.add(P.global.EDIT_ANY_PLAN_DATA);
         global.add(P.global.EDIT_ANY_MEASUREMENT);
         global.add(P.global.CHANGE_ANY_PLAN_VISIBILITY_IN_PROJECTS);
+        global.add(P.global.DELETE_ANY_PLAN);
       } else if (role === 'ftsAdmin') {
         // New Permissions
         global.add(P.global.VIEW_ANY_FLOW);

--- a/src/db/models/authGrant.ts
+++ b/src/db/models/authGrant.ts
@@ -42,9 +42,10 @@ const authGrantModel = (conn: Knex) => {
   const create = (
     data: UserData,
     actor: ParticipantId,
-    date = new Date()
+    date = new Date(),
+    trx?: Knex.Transaction<any, any>
   ): Promise<Instance> => {
-    return conn.transaction(async (trx) => {
+    const createCallback = async (trx: Knex.Transaction<any, any>) => {
       await authGrantLog.create(
         {
           grantee: data.grantee,
@@ -58,11 +59,17 @@ const authGrantModel = (conn: Knex) => {
         }
       );
       return await model.create(data, { trx });
-    });
+    };
+
+    return trx ? createCallback(trx) : conn.transaction(createCallback);
   };
 
-  const update = (data: UserData, actor: ParticipantId): Promise<void> => {
-    return conn.transaction(async (trx) => {
+  const update = (
+    data: UserData,
+    actor: ParticipantId,
+    trx?: Knex.Transaction<any, any>
+  ): Promise<void> => {
+    const updateCallback = async (trx: Knex.Transaction<any, any>) => {
       await authGrantLog.create(
         {
           grantee: data.grantee,
@@ -95,7 +102,9 @@ const authGrantModel = (conn: Knex) => {
           },
         });
       }
-    });
+    };
+
+    return trx ? updateCallback(trx) : conn.transaction(updateCallback);
   };
 
   const createOrUpdate = async (

--- a/src/db/models/authTarget.ts
+++ b/src/db/models/authTarget.ts
@@ -1,5 +1,6 @@
 import * as t from 'io-ts';
 import { defineIDModel } from '../util/id-model';
+import Knex = require('knex');
 
 import { brandedType } from '../../util/io-ts';
 import type { Brand } from '../../util/types';
@@ -21,28 +22,38 @@ const AUTH_TARGET_TYPE = {
   governingEntity: null,
 };
 
-export default defineIDModel({
-  tableName: 'authTarget',
-  fields: {
-    generated: {
-      id: {
-        kind: 'branded-integer',
-        brand: AUTH_TARGET_ID,
+export default (conn: Knex) => {
+  const model = defineIDModel({
+    tableName: 'authTarget',
+    fields: {
+      generated: {
+        id: {
+          kind: 'branded-integer',
+          brand: AUTH_TARGET_ID,
+        },
+      },
+      optional: {
+        targetId: {
+          kind: 'checked',
+          type: t.number,
+        },
+      },
+      required: {
+        type: {
+          kind: 'enum',
+          values: AUTH_TARGET_TYPE,
+        },
       },
     },
-    optional: {
-      targetId: {
-        kind: 'checked',
-        type: t.number,
-      },
-    },
-    required: {
-      type: {
-        kind: 'enum',
-        values: AUTH_TARGET_TYPE,
-      },
-    },
-  },
-  idField: 'id',
-  softDeletionEnabled: false,
-});
+    idField: 'id',
+    softDeletionEnabled: false,
+  })(conn);
+
+  return {
+    ...model,
+    /**
+     * @deprecated Use `deleteAuthTarget` utility method instead
+     */
+    destroy: model.destroy,
+  };
+};


### PR DESCRIPTION
- Add new permission `global.DELETE_ANY_PLAN`, granted to HPC and RPM admins
- Allow to provide a transaction to authGrant.create and `authGrant.update`. Executing these methods in a transaction is vital, so we need a way to specify a transaction
- Introduce auth target deletion util method