### PR TITLE
HPC-9302: Pdf Project Target does not match Project Target stored

### DIFF
--- a/src/db/models/project.ts
+++ b/src/db/models/project.ts
@@ -38,7 +38,7 @@ const PROJECT_IMPLEMENTATION_STATUS = {
   'Ended - Not started and abandoned': null,
 };
 
-const PROJECT_PDF_ENTRY = t.type({
+export const PROJECT_PDF_ENTRY = t.type({
   /**
    * TODO: use something more stable, like UNIX OFFSET as a number
    *
@@ -55,6 +55,7 @@ export const PROJECT_PDF = t.partial({
   anonymous: PROJECT_PDF_ENTRY,
   withComments: PROJECT_PDF_ENTRY,
   commentsOnly: PROJECT_PDF_ENTRY,
+  checkedAt: t.number,
 });
 
 export default defineIDModel({


### PR DESCRIPTION
It's on a mission to sort out those messed-up PDF links in the project. It starts by checking the unchecked or oldest projects and does its thing to patch things up. So it needs to store checked date on pdf of project.