### PR TITLE
Update Postgres image to 14.12

### DIFF
--- a/tests/compose.yml
+++ b/tests/compose.yml
@@ -1,6 +1,6 @@
 services:
   db:
-    image: postgres:14.8-alpine3.18
+    image: postgres:14.12-alpine3.19
     container_name: hpc-postgres-test-api-core
     ports:
       - 6432:5432


### PR DESCRIPTION
This is done to match the production version which is used on AWS RDS, according to the most recent maintenance by OPS in ticket [OPS-10475](https://humanitarian.atlassian.net/browse/OPS-10475).

[OPS-10475]: https://humanitarian.atlassian.net/browse/OPS-10475?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ