### PR TITLE
Add utility method `getProjectVersionImplementationStatus`

### DIFF
--- a/src/lib/data/projectVersions.ts
+++ b/src/lib/data/projectVersions.ts
@@ -1,0 +1,27 @@
+import type { Database } from '../../db';
+import type { InstanceDataOfModel } from '../../db/util/raw-model';
+
+/**
+ * `implementationStatus` is not a real column on `projectVersion`
+ * table, but rather a function that computes implementation status
+ * and can return one of four string values. Since using DB functions
+ * is considered legacy, this method recreates the logic in code.
+ */
+export const getProjectVersionImplementationStatus = async (
+  database: Database,
+  projectVersion: InstanceDataOfModel<Database['projectVersion']>
+): Promise<'published' | 'unpublished' | 'draft' | 'archived'> => {
+  const project = await database.project.get(projectVersion.projectId);
+
+  if (project?.currentPublishedVersionId === projectVersion.id) {
+    return 'published';
+  } else if (project?.latestVersionId === projectVersion.id) {
+    if (project?.currentPublishedVersionId === null) {
+      return 'unpublished';
+    }
+
+    return 'draft';
+  }
+
+  return 'archived';
+};


### PR DESCRIPTION
`implementationStatus` is not a real column on `projectVersion` table, but rather a function that computes implementation status and can return one of four string values. Since using DB functions is considered legacy, this method recreates the logic in code.

For the record, the DB function we're recreating looks like this:
```sql
CREATE FUNCTION public."implementationStatus"(
  public."projectVersion"
) RETURNS CHARACTER VARYING
    LANGUAGE SQL STABLE
    AS $_$
SELECT
  (
    CASE
      WHEN "project"."currentPublishedVersionId" = $1."id" THEN 'published'
      WHEN "project"."currentPublishedVersionId" IS NULL
      AND $1."id" = "project"."latestVersionId" THEN 'unpublished'
      WHEN "project"."currentPublishedVersionId" IS NOT NULL
      AND $1."id" = "project"."latestVersionId" THEN 'draft'
      ELSE 'archived'
    END
  )
FROM
  "project"
WHERE
  "project"."id" = $1."projectId" $_$;
```