### PR TITLE
Remove TODO comment that cannot be done

### DIFF
--- a/src/db/deletion/project.ts
+++ b/src/db/deletion/project.ts
@@ -22,7 +22,7 @@ export const deleteProjectById = async (
 
   // Cannot delete already published project
   if (
-    project.latestVersionId !== null && // TODO: Remove once HPC-9121 is done and `latestVersionId` can no longer be `null`
+    project.latestVersionId !== null &&
     project.currentPublishedVersionId === project.latestVersionId
   ) {
     throw new PreconditionFailedError(


### PR DESCRIPTION
After finishing work on [HPC-9121](https://humanitarian.atlassian.net/browse/HPC-9121), ticket [HPC-9637](https://humanitarian.atlassian.net/browse/HPC-9637) was opened to track how we can set column `latestVersionId` in `project` table to be `NOT NULL`. But, turns out that will not be possible, so we need this check, cannot remove it, as TODO desired.

[HPC-9121]: https://humanitarian.atlassian.net/browse/HPC-9121?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[HPC-9637]: https://humanitarian.atlassian.net/browse/HPC-9637?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ