### PR TITLE
HPC-9832: Make `destroy` supports `softDeletionEnabled`

### DIFF
--- a/src/db/util/raw-model.ts
+++ b/src/db/util/raw-model.ts
@@ -80,6 +80,7 @@ export type UpdateFn<F extends FieldDefinition> = (args: {
 export type DestroyFn<F extends FieldDefinition> = (args: {
   where: WhereCond<F>;
   trx?: Knex.Transaction<any, any>;
+  hardDelete?: boolean;
 }) => Promise<number>;
 
 export type TruncateFn = (trx?: Knex.Transaction<any, any>) => Promise<void>;

--- a/src/db/util/sequelize-model.ts
+++ b/src/db/util/sequelize-model.ts
@@ -11,6 +11,7 @@ import {
   defineRawModel,
   type CreateFn,
   type CreateManyFn,
+  type DestroyFn,
   type FindFn,
   type FindOneFn,
   type ModelInitializer,
@@ -182,6 +183,20 @@ export const defineSequelizeModel =
       });
     };
 
+    const destroy: DestroyFn<Fields> = async (args) => {
+      if (!opts.softDeletionEnabled || args.hardDelete) {
+        return model.destroy(args);
+      }
+      return (
+        await model.update({
+          ...args,
+          values: {
+            deletedAt: masterConn.fn.now(3),
+          } as any,
+        })
+      ).length;
+    };
+
     return {
       ...model,
       find,
@@ -189,5 +204,6 @@ export const defineSequelizeModel =
       create,
       createMany,
       update,
+      destroy,
     };
   };


### PR DESCRIPTION
From [this](https://github.com/UN-OCHA/hpc_service/pull/3571#pullrequestreview-2395741396) comment, I was initially trying to add `hardDelete` option to destroy method in `src/db/util/sequelize-model.ts`. But appears that it wasn't even support `softDeletionEnabled` option.