### PR TITLE
Make some columns required

### DIFF
--- a/src/db/models/attachment.ts
+++ b/src/db/models/attachment.ts
@@ -37,10 +37,6 @@ export default defineLegacyVersionedModel({
         kind: 'branded-integer',
         brand: ATTACHMENT_PROTOTYPE_ID,
       },
-      planId: {
-        kind: 'branded-integer',
-        brand: PLAN_ID,
-      },
     },
     required: {
       objectId: {
@@ -50,6 +46,10 @@ export default defineLegacyVersionedModel({
       objectType: {
         kind: 'checked',
         type: ATTACHMENT_OBJECT_TYPE,
+      },
+      planId: {
+        kind: 'branded-integer',
+        brand: PLAN_ID,
       },
       type: {
         kind: 'checked',

--- a/src/db/models/organization.ts
+++ b/src/db/models/organization.ts
@@ -33,8 +33,6 @@ export default defineIDModel({
     },
     required: {
       name: { kind: 'checked', type: t.string },
-    },
-    accidentallyOptional: {
       abbreviation: { kind: 'checked', type: t.string },
     },
   },


### PR DESCRIPTION
- Admin command `delete-broken-attachment` developed for [HPC-9832](https://humanitarian.atlassian.net/browse/HPC-9832) has deleted attachments which had their `planId` column equal to `NULL` before, so we can make this column required now, as there is no data anymore which made it accidentally optional
- In `organization` table, there are no records where `abbreviation` is `NULL`, so we can make it required now. In the old dumps, the organization with ID 1585, named "Kraft Foods Foundation", didn't specify `abbreviation` and there may have been others too, but all records have non-null `abbreviation` now

[HPC-9832]: https://humanitarian.atlassian.net/browse/HPC-9832?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ