### PR TITLE
HPC-9997: Simplify `support` array in `PLAN_ENTITY_VERSION_VALUE` codec

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@unocha/hpc-api-core",
-  "version": "10.7.0",
+  "version": "10.7.1",
   "description": "Core libraries supporting HPC.Tools API Backend",
   "license": "Apache-2.0",
   "private": false,

--- a/src/db/models/planEntityVersion.ts
+++ b/src/db/models/planEntityVersion.ts
@@ -29,37 +29,22 @@ const PLAN_ENTITY_VERSION_REF = t.partial({
   entityPrototypeId: ENTITY_PROTOTYPE_ID,
 });
 
-export const PLAN_ENTITY_VERSION_VALUE = t.intersection([
-  t.type({
-    categories: t.array(CATEGORY_ID),
-    description: t.string,
-    type: LOCALIZED_PLURAL_STRING,
-  }),
-  t.partial({
-    support: t.union([
-      t.array(
-        t.union([
-          /**
-           * TODO: Some records in the database have `null` inside `support` array,
-           * which is problematic. Stricter validation of data being stored should
-           * be done, existing values removed and then `null` removed from this type.
-           */
-          t.null,
-          PLAN_ENTITY_VERSION_REF,
-        ])
-      ),
+export const PLAN_ENTITY_VERSION_VALUE = t.type({
+  categories: t.array(CATEGORY_ID),
+  description: t.string,
+  type: LOCALIZED_PLURAL_STRING,
+  support: t.array(
+    t.union([
       /**
-       * TODO: Some records have object with key "0" instead of array of objects,
-       * which is absolutely ridiculous. We need to have stricter validation of
-       * data being stored here, convert existing cases to arrays, and then remove
-       * this awful type edge case
+       * TODO: Some records in the database have `null` inside `support` array,
+       * which is problematic. Stricter validation of data being stored should
+       * be done, existing values removed and then `null` removed from this type.
        */
-      t.partial({
-        0: PLAN_ENTITY_VERSION_REF,
-      }),
-    ]),
-  }),
-]);
+      t.null,
+      PLAN_ENTITY_VERSION_REF,
+    ])
+  ),
+});
 export type PlanEntityVersionValue = t.TypeOf<typeof PLAN_ENTITY_VERSION_VALUE>;
 
 export default defineLegacyVersionedModel({


### PR DESCRIPTION
> [!NOTE]  
> To be merged after admin command from https://github.com/UN-OCHA/hpc_service/pull/3684 is run

After fixing database records so that `support` array is initialized everywhere and it can no longer have object with key `"0"`, we can simplify the codec `PLAN_ENTITY_VERSION_VALUE`