### PR TITLE
Disallow `null` elements in `support` array

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@unocha/hpc-api-core",
-  "version": "10.7.1",
+  "version": "10.7.2",
   "description": "Core libraries supporting HPC.Tools API Backend",
   "license": "Apache-2.0",
   "private": false,

--- a/src/db/models/planEntityVersion.ts
+++ b/src/db/models/planEntityVersion.ts
@@ -33,17 +33,7 @@ export const PLAN_ENTITY_VERSION_VALUE = t.type({
   categories: t.array(CATEGORY_ID),
   description: t.string,
   type: LOCALIZED_PLURAL_STRING,
-  support: t.array(
-    t.union([
-      /**
-       * TODO: Some records in the database have `null` inside `support` array,
-       * which is problematic. Stricter validation of data being stored should
-       * be done, existing values removed and then `null` removed from this type.
-       */
-      t.null,
-      PLAN_ENTITY_VERSION_REF,
-    ])
-  ),
+  support: t.array(PLAN_ENTITY_VERSION_REF),
 });
 export type PlanEntityVersionValue = t.TypeOf<typeof PLAN_ENTITY_VERSION_VALUE>;
 


### PR DESCRIPTION
> [!NOTE]  
> To be merged after admin command from https://github.com/UN-OCHA/hpc_service/pull/3685 is run

After fixing all the records which had `null` in `support` array, we can simplify the codec.