### PR TITLE
HPC-10000: Remove `null` from `planEntityIds` codec

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@unocha/hpc-api-core",
-  "version": "10.8.0",
+  "version": "10.8.1",
   "description": "Core libraries supporting HPC.Tools API Backend",
   "license": "Apache-2.0",
   "private": false,

--- a/src/db/models/planEntityVersion.ts
+++ b/src/db/models/planEntityVersion.ts
@@ -19,13 +19,7 @@ export const PLAN_ENTITY_VERSION_ID = brandedType<number, PlanEntityVersionId>(
 );
 
 const PLAN_ENTITY_VERSION_REF = t.partial({
-  /**
-   * TODO: Some values in the database seem to have null values in this
-   * array, which is problematic. We need to have stricter validation of
-   * data being stored here, repair existing values, and then remove null
-   * from this type
-   */
-  planEntityIds: t.array(t.union([t.null, PLAN_ENTITY_ID])),
+  planEntityIds: t.array(PLAN_ENTITY_ID),
   entityPrototypeId: ENTITY_PROTOTYPE_ID,
 });
 


### PR DESCRIPTION
To be merged after admin command from https://github.com/UN-OCHA/hpc_service/pull/3686 is run