### PR TITLE
HPC-10005: Plan visibility for new projects

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@unocha/hpc-api-core",
-  "version": "10.7.2",
+  "version": "10.8.0",
   "description": "Core libraries supporting HPC.Tools API Backend",
   "license": "Apache-2.0",
   "private": false,

--- a/src/db/models/planVersion.ts
+++ b/src/db/models/planVersion.ts
@@ -24,6 +24,7 @@ const PLAN_VERSION_CLUSTER_SELECTION_TYPE = t.keyof({
 const PLAN_VISIBILITY_PREFERENCES = t.type({
   isDisaggregationForCaseloads: t.boolean,
   isDisaggregationForIndicators: t.boolean,
+  isForNewHPCProjects: t.boolean,
 });
 
 export default defineLegacyVersionedModel({


### PR DESCRIPTION
[`src/db/models/planVersion.ts`](diffhunk://#diff-1e167fab1400eda8ac0b547aeeb47d9abc44cb732c0ed93e6a2dbcc6d675fa57R27): Added `isForNewHPCProjects` as a new boolean property to `PLAN_VISIBILITY_PREFERENCES`.