### PR TITLE
HPC-10029: Optimize `toCamelCase`

### DIFF
--- a/bin/test.sh
+++ b/bin/test.sh
@@ -84,6 +84,7 @@ if [ $KEEP -eq 0 ]; then
 fi
 
 yarn jest "$COMMAND_ARGS" $FORCE_STOP_JEST
+TEST_EXIT_CODE=$?
 
 if [ $KEEP -eq 0 ]; then
   # Stop Docker containers
@@ -91,3 +92,6 @@ if [ $KEEP -eq 0 ]; then
   moveToTestDir
   docker compose down
 fi
+
+# Pass through the exit code of the unit tests
+exit $TEST_EXIT_CODE

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@unocha/hpc-api-core",
-  "version": "10.10.0",
+  "version": "10.10.1",
   "description": "Core libraries supporting HPC.Tools API Backend",
   "license": "Apache-2.0",
   "private": false,

--- a/src/lib/data/attachments.ts
+++ b/src/lib/data/attachments.ts
@@ -445,6 +445,7 @@ const getDisaggregations = ({
 
   const disaggregatedCategories = disaggregated.categories;
   const disaggregatedLocations = disaggregated.locations;
+  const camelCaseMap = new Map<string, string>();
 
   const disaggregationData: ExtendedDisaggregationData = [];
 
@@ -519,10 +520,16 @@ const getDisaggregations = ({
 
         const value = cleanNumberVal(dmCell);
 
+        let metricName = metric.name;
+        if (specificMetricTypes?.length) {
+          if (!camelCaseMap.has(metric.name)) {
+            camelCaseMap.set(metric.name, toCamelCase(metric.name));
+          }
+          metricName = camelCaseMap.get(metric.name) ?? 'N/A';
+        }
+
         dataMatrix.push({
-          metricType: !specificMetricTypes?.length
-            ? metric.type
-            : toCamelCase(metric.name),
+          metricType: !specificMetricTypes?.length ? metric.type : metricName,
           lIndex,
           cIndex,
           value: value !== null && !Number.isNaN(value) ? value : null,

--- a/src/util/index.ts
+++ b/src/util/index.ts
@@ -278,21 +278,13 @@ export const cleanNumberVal = (value: number | string | null): number | null =>
       ? parseFloat(value.trim().replaceAll(',', ''))
       : null;
 
-export const toCamelCase = (originalString: string) => {
-  let isNextLetterUppercase = false;
-  let convertedString = '';
-
-  for (const char of originalString) {
-    if (char === ' ') {
-      isNextLetterUppercase = true;
-      continue;
-    }
-
-    convertedString += isNextLetterUppercase
-      ? char.toUpperCase()
-      : char.toLowerCase();
-    isNextLetterUppercase = false;
-  }
-
-  return convertedString;
-};
+export const toCamelCase = (originalString: string) =>
+  originalString
+    .trim()
+    .split(' ')
+    .map((word, index) =>
+      index === 0
+        ? word.toLowerCase()
+        : word.charAt(0).toUpperCase() + word.slice(1).toLowerCase()
+    )
+    .join('');

--- a/tests/utils/util.spec.ts
+++ b/tests/utils/util.spec.ts
@@ -2,9 +2,17 @@ import { toCamelCase } from '../../src/util';
 
 describe('Test utility functions', () => {
   it('should convert string to camel case', () => {
+    expect(toCamelCase('')).toBe('');
     expect(toCamelCase('Reached')).toBe('reached');
     expect(toCamelCase('Cumulative reach')).toBe('cumulativeReach');
     expect(toCamelCase('Double  space')).toBe('doubleSpace');
+    expect(toCamelCase('  leading space')).toBe('leadingSpace');
+    expect(toCamelCase('trailing space  ')).toBe('trailingSpace');
+    expect(toCamelCase('  both ends  ')).toBe('bothEnds');
     expect(toCamelCase('with three words')).toBe('withThreeWords');
+    expect(toCamelCase('Mixed CASE')).toBe('mixedCase');
+    expect(toCamelCase('Another Test CASE')).toBe('anotherTestCase');
+    expect(toCamelCase('version 1.0')).toBe('version1.0');
+    expect(toCamelCase('2fast 2furious')).toBe('2fast2furious');
   });
 });


### PR DESCRIPTION
In the ticket, it was reported that call to HPC API endpoint `v2/plan/1185/responseMonitoring?includeCaseloadDisaggregation=true&includeIndicatorDisaggregation=false&disaggregationOnlyTotal=false` doesn't complete until timeout is reached. After investigation using profiling tool of DevTools, I found that calls to `toCamelCase` are actually responsible to great extent.

First, I have tried various ways of optimizing the method itself, to only have managed getting from ~45 seconds to ~25 seconds while processing attachment data on HPC API side. Without calls to `toCamelCase`, that code took 5 seconds. Even Lodash's implementation was worse than this, at around 35 seconds, all measured on local. So, just optimization didn't cut it, so I decided to "cache" the responses of this method, which brought down number of its invocations from 16,850,784 to just 4,584! This huge reduction helped tremendously with performance.