### PR TITLE
Add `range` helper method

### DIFF
--- a/src/util/index.ts
+++ b/src/util/index.ts
@@ -288,3 +288,6 @@ export const toCamelCase = (originalString: string) =>
         : word.charAt(0).toUpperCase() + word.slice(1).toLowerCase()
     )
     .join('');
+
+export const range = (size: number, startAt: number = 0): readonly number[] =>
+  [...Array(size).keys()].map((i) => i + startAt);


### PR DESCRIPTION
Unlike other programming languages, JS is lacking native way of creating a number range and it isn't unusual to have a need to iterate a static number of items. I thought it would be useful to be able to write code like this:
```js
for (const i of range(10)) {
  console.log(i);
}
```

Credits go to [this StackOverflow answer](https://stackoverflow.com/a/10050831).