### PR TITLE
Remove unnecessary usages of `any`

### DIFF
--- a/src/auth/index.ts
+++ b/src/auth/index.ts
@@ -498,7 +498,7 @@ export const deleteAuthTarget = async (
   database: Database,
   where: UserDataOfModel<Database['authTarget']>,
   actor: ParticipantId,
-  trx: Knex.Transaction<any, any>
+  trx: Knex.Transaction
 ): Promise<void> => {
   const authTargets = await database.authTarget.find({ where, trx });
   const authGrants = await database.authGrant.find({

--- a/src/db/deletion/project.ts
+++ b/src/db/deletion/project.ts
@@ -9,7 +9,7 @@ export const deleteProjectById = async (
   database: Database,
   projectToDelete: ProjectId,
   authGrantRevoker: ParticipantId,
-  trx: Knex.Transaction<any, any>
+  trx: Knex.Transaction
 ) => {
   const project = await database.project.findOne({
     where: { id: projectToDelete },

--- a/src/db/models/authGrant.ts
+++ b/src/db/models/authGrant.ts
@@ -43,9 +43,9 @@ const authGrantModel = (masterConn: Knex, replicaConn?: Knex) => {
     data: UserData,
     actor: ParticipantId,
     date = new Date(),
-    trx?: Knex.Transaction<any, any>
+    trx?: Knex.Transaction
   ): Promise<Instance> => {
-    const createCallback = async (trx: Knex.Transaction<any, any>) => {
+    const createCallback = async (trx: Knex.Transaction) => {
       await authGrantLog.create(
         {
           grantee: data.grantee,
@@ -67,9 +67,9 @@ const authGrantModel = (masterConn: Knex, replicaConn?: Knex) => {
   const update = (
     data: UserData,
     actor: ParticipantId,
-    trx?: Knex.Transaction<any, any>
+    trx?: Knex.Transaction
   ): Promise<void> => {
-    const updateCallback = async (trx: Knex.Transaction<any, any>) => {
+    const updateCallback = async (trx: Knex.Transaction) => {
       await authGrantLog.create(
         {
           grantee: data.grantee,

--- a/src/db/util/raw-model.ts
+++ b/src/db/util/raw-model.ts
@@ -15,14 +15,14 @@ import { dataValidator } from './validation';
 export type CreateFn<F extends FieldDefinition> = (
   data: UserDataOf<F>,
   opts?: {
-    trx?: Knex.Transaction<any, any>;
+    trx?: Knex.Transaction;
   }
 ) => Promise<InstanceDataOf<F>>;
 
 export type CreateManyFn<F extends FieldDefinition> = (
   data: Array<UserDataOf<F>>,
   opts?: {
-    trx?: Knex.Transaction<any, any>;
+    trx?: Knex.Transaction;
   }
 ) => Promise<Array<InstanceDataOf<F>>>;
 
@@ -45,7 +45,7 @@ export type FindFn<F extends FieldDefinition, AdditionalArgs = {}> = (
      * from disabling validation are worth the risk!
      */
     skipValidation?: boolean;
-    trx?: Knex.Transaction<any, any>;
+    trx?: Knex.Transaction;
     /**
      * Uses `DISTINCT ON`, which is a feature unique to PostgreSQL.
      *
@@ -62,7 +62,7 @@ export type FindFn<F extends FieldDefinition, AdditionalArgs = {}> = (
 export type FindOneFn<F extends FieldDefinition, AdditionalArgs = {}> = (
   args: {
     where: WhereCond<F>;
-    trx?: Knex.Transaction<any, any>;
+    trx?: Knex.Transaction;
   } & AdditionalArgs
 ) => Promise<InstanceDataOf<F> | null>;
 
@@ -74,22 +74,22 @@ export type UpdateFn<F extends FieldDefinition> = (args: {
    * from disabling validation are worth the risk!
    */
   skipValidation?: boolean;
-  trx?: Knex.Transaction<any, any>;
+  trx?: Knex.Transaction;
 }) => Promise<Array<InstanceDataOf<F>>>;
 
 export type DestroyFn<F extends FieldDefinition, AdditionalArgs = {}> = (
   args: {
     where: WhereCond<F>;
-    trx?: Knex.Transaction<any, any>;
+    trx?: Knex.Transaction;
   } & AdditionalArgs
 ) => Promise<number>;
 
-export type TruncateFn = (trx?: Knex.Transaction<any, any>) => Promise<void>;
+export type TruncateFn = (trx?: Knex.Transaction) => Promise<void>;
 
 export type CountFn<F extends FieldDefinition, AdditionalArgs = {}> = (
   args?: {
     where?: WhereCond<F>;
-    trx?: Knex.Transaction<any, any>;
+    trx?: Knex.Transaction;
     /**
      * Will produce `SELECT COUNT(DISTINCT "columnName")` and if there
      * is an expression in `COUNT`, it will compute the number of input

--- a/src/db/util/validation.ts
+++ b/src/db/util/validation.ts
@@ -33,7 +33,7 @@ export const validateModelAgainstTable = async (
    */
   const getDbCols = (await modelInternals
     .query()
-    .columnInfo()) as any as KnexColumns;
+    .columnInfo()) as unknown as KnexColumns;
   const dbCols = new Map(
     Object.entries(getDbCols).map(([name, col]) => [name, col])
   );

--- a/src/util/index.ts
+++ b/src/util/index.ts
@@ -69,7 +69,7 @@ export const sortBy =
 /**
  * Obtain the type parameter of a promise type
  */
-export type PromiseType<P extends Promise<any>> =
+export type PromiseType<P extends Promise<unknown>> =
   P extends Promise<infer V> ? V : never;
 
 /**
@@ -197,8 +197,8 @@ export const mapObjectEntries = <K extends string | symbol, V1, V2>(
   ) as { [key in K]: V2 };
 };
 
-export type MapValue<M extends Map<any, any>> =
-  M extends Map<any, infer V> ? V : unknown;
+export type MapValue<M extends Map<unknown, unknown>> =
+  M extends Map<unknown, infer V> ? V : unknown;
 
 export const getOrCreate = <K, V>(map: Map<K, V>, k: K, val: () => V): V => {
   let v = map.get(k);

--- a/src/util/index.ts
+++ b/src/util/index.ts
@@ -215,10 +215,8 @@ export const getOrCreate = <K, V>(map: Map<K, V>, k: K, val: () => V): V => {
  * JSON type definition
  */
 export type JSONPrimitive = string | number | boolean | null;
-export type JSONValue = JSONPrimitive | JSONObject | JSONArray;
+export type JSONValue = JSONPrimitive | JSONObject | JSONValue[];
 export type JSONObject = { [member: string]: JSONValue };
-// eslint-disable-next-line @typescript-eslint/no-empty-interface
-export interface JSONArray extends Array<JSONValue> {}
 
 /**
  * Retrieve a value from an annotated map that we expect to be present,


### PR DESCRIPTION
Since `Knex.Transaction` already defaults to `any` in its generic type definitions, us specifying them explicitly just floods our files with linter warnings about explicit usages of `any`.