### PR TITLE
Check formatting & lint files with `.cjs` & `.mjs` extensions

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -16,6 +16,6 @@ export default [
     },
   },
   {
-    ignores: ['.github', '.prettierrc.js', 'eslint.config.js'],
+    ignores: ['.github', 'prettier.config.mjs', 'eslint.config.mjs'],
   },
 ];

--- a/package.json
+++ b/package.json
@@ -45,6 +45,6 @@
       "prettier --check",
       "eslint"
     ],
-    "*.{js,jsx,ts,tsx,md,json}": "prettier --check"
+    "*.{js,ts,md,json}": "prettier --check"
   }
 }

--- a/package.json
+++ b/package.json
@@ -45,6 +45,6 @@
       "prettier --check",
       "eslint"
     ],
-    "*.{js,ts,md,json}": "prettier --check"
+    "*.{js,ts,md,json,yml,yaml}": "prettier --check"
   }
 }

--- a/package.json
+++ b/package.json
@@ -41,10 +41,10 @@
     "typescript": "^5.8.2"
   },
   "lint-staged": {
-    "*.{ts,js}": [
+    "*.{ts,js,cjs,mjs}": [
       "prettier --check",
       "eslint"
     ],
-    "*.{js,ts,md,json,yml,yaml}": "prettier --check"
+    "*.{js,cjs,mjs,ts,md,json,yml,yaml}": "prettier --check"
   }
 }

--- a/src/db/util/sequelize-model.ts
+++ b/src/db/util/sequelize-model.ts
@@ -1,7 +1,3 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
-/*
- * Use of `any` in this module is generally deliberate to help with generics
- */
 import merge = require('lodash/merge');
 
 import { Cond, Op } from './conditions';


### PR DESCRIPTION
Besides what's in the title, I also slipped in two more changes:
- In PR #232, when we moved to ESM version of repo tools, we missed changing the names of config files
- The removal of unused eslint-disable directive could have been slipped in PR #233, since it already did the similar thing