### PR TITLE
Add array chunking utility method

### DIFF
--- a/src/util/consts.ts
+++ b/src/util/consts.ts
@@ -1,0 +1,14 @@
+/**
+ * Maximum number of clauses allowed when parsing a boolean
+ * query string in Solr; 1024 is the default value
+ *
+ * [Source](https://solr.apache.org/guide/8_1/query-settings-in-solrconfig.html#maxbooleanclauses)
+ */
+export const SOLR_MAX_BOOLEAN_CLAUSES = 1024;
+
+/**
+ * The maximum number of query parameters in PostgreSQL is 65,535
+ *
+ * [Source](https://www.postgresql.org/docs/current/limits.html)
+ */
+export const PG_MAX_QUERY_PARAMS = 2 ** 16 - 1;

--- a/src/util/index.ts
+++ b/src/util/index.ts
@@ -1,3 +1,5 @@
+import type { NonNegativeInteger } from './types';
+
 export const isDefined = <T>(v: T | null | undefined): v is T =>
   v !== null && v !== undefined;
 
@@ -287,5 +289,7 @@ export const toCamelCase = (originalString: string) =>
     )
     .join('');
 
-export const range = (size: number, startAt: number = 0): readonly number[] =>
-  Array.from({ length: size }, (_, i) => i + startAt);
+export const range = <N extends number>(
+  size: NonNegativeInteger<N>,
+  startAt: number = 0
+): readonly number[] => Array.from({ length: size }, (_, i) => i + startAt);

--- a/src/util/index.ts
+++ b/src/util/index.ts
@@ -293,3 +293,11 @@ export const range = <N extends number>(
   size: NonNegativeInteger<N>,
   startAt: number = 0
 ): readonly number[] => Array.from({ length: size }, (_, i) => i + startAt);
+
+export const splitIntoChunks = <T, N extends number>(
+  arr: readonly T[],
+  size: NonNegativeInteger<N>
+): T[][] =>
+  Array.from({ length: Math.ceil(arr.length / size) }, (_, i) =>
+    arr.slice(i * size, i * size + size)
+  );

--- a/src/util/types.ts
+++ b/src/util/types.ts
@@ -24,6 +24,12 @@ export type Brand<T, S extends { s: symbol }, Label extends string = ''> = T & {
 export const createBrandedValue = <T, B extends Brand<T, any, any>>(v: T): B =>
   v as unknown as B;
 
+export type NonNegativeInteger<T extends number> = `${T}` extends
+  | `-${string}`
+  | `${string}.${string}`
+  ? never
+  : T;
+
 export const getTableColumns = <
   T extends { _internals: { fields: FieldDefinition } },
 >(

--- a/tests/compose.yml
+++ b/tests/compose.yml
@@ -1,6 +1,6 @@
 services:
   db:
-    image: postgres:14.12-alpine3.19
+    image: postgres:14.17-alpine3.21
     container_name: hpc-postgres-test-api-core
     ports:
       - 6432:5432

--- a/tests/utils/util.spec.ts
+++ b/tests/utils/util.spec.ts
@@ -1,4 +1,4 @@
-import { range, toCamelCase } from '../../src/util';
+import { range, splitIntoChunks, toCamelCase } from '../../src/util';
 
 describe('Test utility functions', () => {
   it('should convert string to camel case', () => {
@@ -36,6 +36,49 @@ describe('Test utility functions', () => {
 
     it('should handle negative start values', () => {
       expect(range(5, -3)).toEqual([-3, -2, -1, 0, 1]);
+    });
+  });
+
+  describe('splitIntoChunks', () => {
+    it('should split an array into equal-sized chunks', () => {
+      expect(splitIntoChunks(range(6, 1), 2)).toEqual([
+        [1, 2],
+        [3, 4],
+        [5, 6],
+      ]);
+    });
+
+    it('should handle arrays where the last chunk is smaller', () => {
+      expect(splitIntoChunks(range(5, 1), 2)).toEqual([[1, 2], [3, 4], [5]]);
+      expect(splitIntoChunks(range(17, 1), 5)).toEqual([
+        [1, 2, 3, 4, 5],
+        [6, 7, 8, 9, 10],
+        [11, 12, 13, 14, 15],
+        [16, 17],
+      ]);
+    });
+
+    it('should return an empty array when input is empty', () => {
+      expect(splitIntoChunks([], 3)).toEqual([]);
+    });
+
+    it('should handle chunk size larger than the array length', () => {
+      expect(splitIntoChunks(range(3, 1), 10)).toEqual([[1, 2, 3]]);
+    });
+
+    it('should handle chunk size of 1', () => {
+      expect(splitIntoChunks(range(3, 1), 1)).toEqual([[1], [2], [3]]);
+    });
+
+    it('should handle chunk size equal to array length', () => {
+      expect(splitIntoChunks(range(4, 1), 4)).toEqual([[1, 2, 3, 4]]);
+    });
+
+    it('should work with an array of strings', () => {
+      expect(splitIntoChunks(['a', 'b', 'c', 'd'], 2)).toEqual([
+        ['a', 'b'],
+        ['c', 'd'],
+      ]);
     });
   });
 });

--- a/tests/utils/util.spec.ts
+++ b/tests/utils/util.spec.ts
@@ -1,4 +1,4 @@
-import { toCamelCase } from '../../src/util';
+import { range, toCamelCase } from '../../src/util';
 
 describe('Test utility functions', () => {
   it('should convert string to camel case', () => {
@@ -14,5 +14,28 @@ describe('Test utility functions', () => {
     expect(toCamelCase('Another Test CASE')).toBe('anotherTestCase');
     expect(toCamelCase('version 1.0')).toBe('version1.0');
     expect(toCamelCase('2fast 2furious')).toBe('2fast2furious');
+  });
+
+  describe('range', () => {
+    it('should generate a sequence starting from 0 by default', () => {
+      expect(range(5)).toEqual([0, 1, 2, 3, 4]);
+    });
+
+    it('should generate a sequence starting from a custom value', () => {
+      expect(range(5, 10)).toEqual([10, 11, 12, 13, 14]);
+    });
+
+    it('should return an empty array when size is 0', () => {
+      expect(range(0)).toEqual([]);
+    });
+
+    it('should handle size of 1', () => {
+      expect(range(1)).toEqual([0]);
+      expect(range(1, 5)).toEqual([5]);
+    });
+
+    it('should handle negative start values', () => {
+      expect(range(5, -3)).toEqual([-3, -2, -1, 0, 1]);
+    });
   });
 });


### PR DESCRIPTION
This util method is moved here [from hpc_service](https://github.com/UN-OCHA/hpc_service/blob/0db71b2516e1f62bd11ff13076712b841855a084/app/commands/util/common.ts#L76-L82). Once we merge + release this code, we should replace usages in hpc_service and delete the definition from there.

Also defined a Solr & PostgreSQL constants that will likely be usually used with chunking method, but these weren't defined globally, just in [some temporary admin commands](https://github.com/UN-OCHA/hpc_service/blob/0db71b2516e1f62bd11ff13076712b841855a084/app/commands/commands/temp-clean-broken-plan-links.ts#L15) that I've been adding lately. Notice that I was using 2^15 in there, because I wanted to be on the safe side, but theoretical limit is 2^16 - 1. If you think we should play it safe, we can define 2^15 here too.