### PR TITLE
HPC-9905: Upgrade to Node.js v22

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
         uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
       - name: Install packages
         run: yarn install --frozen-lockfile
       - name: TypeScript compiler checks
@@ -30,7 +30,7 @@ jobs:
         uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
       - name: Install packages
         run: yarn install --frozen-lockfile
       - name: Run Unit Tests

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
           registry-url: 'https://registry.npmjs.org'
       - run: npm install
       - run: npm publish

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@unocha/hpc-api-core",
-  "version": "12.1.0",
+  "version": "13.0.0",
   "description": "Core libraries supporting HPC.Tools API Backend",
   "license": "Apache-2.0",
   "private": false,

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "lint": "yarn lint-prettier && yarn lint-eslint"
   },
   "engines": {
-    "node": ">=20.19.0",
+    "node": ">=20.19.0 || >=22.14.0",
     "yarn": ">=1.22.22"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "lint": "yarn lint-prettier && yarn lint-eslint"
   },
   "engines": {
-    "node": ">=20.15.1",
+    "node": ">=20.19.0",
     "yarn": ">=1.22.22"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "@types/jest": "^29.5.14",
     "@types/node": "^22.13.17",
     "@types/pg": "^8.11.11",
-    "@unocha/hpc-repo-tools": "^6.4.0",
+    "@unocha/hpc-repo-tools": "^7.0.0",
     "eslint": "^9.23.0",
     "husky": "^9.1.7",
     "jest": "^29.7.0",

--- a/src/auth/hid.ts
+++ b/src/auth/hid.ts
@@ -10,6 +10,9 @@ const HID_ACCOUNT_INFO = t.type({
   name: t.string,
   email: t.string,
 });
+const HID_MESSAGE = t.type({
+  message: t.string,
+});
 
 export type HIDInfo = t.TypeOf<typeof HID_ACCOUNT_INFO>;
 
@@ -58,7 +61,10 @@ export const getHidInfo = async (
     if (!res.ok) {
       if (res.status === 401) {
         const r = await res.json();
-        const message = (r.message as string) || 'Invalid Token';
+        if (!HID_MESSAGE.is(r)) {
+          throw new ForbiddenError('Invalid Token');
+        }
+        const message = r.message;
         HID_CACHE.store(token, { type: 'forbidden', message });
         throw new ForbiddenError(message);
       } else {

--- a/src/lib/data/projects.ts
+++ b/src/lib/data/projects.ts
@@ -454,13 +454,16 @@ export const getProjectBudgetsByOrgAndCluster = async <
        * but in some cases (e.g. multi-org projects where both have been merged)
        * it may not be possible to automatically determine what the fix is
        */
-      const missingOrgs = [...budgetOrgIDs].filter((id) => !prvOrgIDs.has(id));
-      const unusedOrgs = [...prvOrgIDs].filter((id) => !budgetOrgIDs.has(id));
+      const missingOrgs = budgetOrgIDs.difference(prvOrgIDs);
+      const unusedOrgs = prvOrgIDs.difference(budgetOrgIDs);
 
-      if (missingOrgs.length === 1 && unusedOrgs.length === 1) {
+      if (missingOrgs.size === 1 && unusedOrgs.size === 1) {
+        const [missingOrg] = missingOrgs;
+        const [unusedOrg] = unusedOrgs;
+
         for (const i of projectResult) {
-          if (i.organization === missingOrgs[0]) {
-            i.organization = unusedOrgs[0];
+          if (i.organization === missingOrg) {
+            i.organization = unusedOrg;
           }
         }
       } else {

--- a/src/lib/data/projects.ts
+++ b/src/lib/data/projects.ts
@@ -7,10 +7,13 @@ import type { ProjectId } from '../../db/models/project';
 import type { Database } from '../../db/type';
 import { Op } from '../../db/util/conditions';
 import type { InstanceOfModel } from '../../db/util/types';
-import { getRequiredData, groupObjectsByProperty } from '../../util';
+import {
+  areSetsEqual,
+  getRequiredData,
+  groupObjectsByProperty,
+} from '../../util';
 import { createBrandedValue } from '../../util/types';
 import type { SharedLogContext } from '../logging';
-import isEqual = require('lodash/isEqual');
 
 /**
  * The `name` value used across all budget segments that are segmented by
@@ -442,7 +445,7 @@ export const getProjectBudgetsByOrgAndCluster = async <
       )
     );
 
-    if (!isEqual(budgetOrgIDs, prvOrgIDs)) {
+    if (!areSetsEqual(budgetOrgIDs, prvOrgIDs)) {
       /*
        * A project's organizations have been updated (likely due to merging)
        * but the project budget segments have not been correctly updated.

--- a/src/util/index.ts
+++ b/src/util/index.ts
@@ -301,3 +301,6 @@ export const splitIntoChunks = <T, N extends number>(
   Array.from({ length: Math.ceil(arr.length / size) }, (_, i) =>
     arr.slice(i * size, i * size + size)
   );
+
+export const areSetsEqual = <T>(a: Set<T>, b: Set<T>): boolean =>
+  a.symmetricDifference(b).size === 0;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es2023",
+    "target": "ES2024",
     "module": "commonjs",
     "declaration": true,
     "outDir": "./",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,5 @@
 {
   "compilerOptions": {
-    /* Visit https://aka.ms/tsconfig.json to read more about this file */
-
     "target": "es2023",
     "module": "commonjs",
     "declaration": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "target": "ES2024",
+    "lib": ["ES2024", "ESNext.Collection", "ESNext.Iterator"],
     "module": "commonjs",
     "declaration": true,
     "outDir": "./",

--- a/yarn.lock
+++ b/yarn.lock
@@ -929,10 +929,10 @@
     "@typescript-eslint/types" "8.29.0"
     eslint-visitor-keys "^4.2.0"
 
-"@unocha/hpc-repo-tools@^6.4.0":
-  version "6.4.0"
-  resolved "https://registry.yarnpkg.com/@unocha/hpc-repo-tools/-/hpc-repo-tools-6.4.0.tgz#ff6b60b8b869a84e24397905d41720913a1b43a9"
-  integrity sha512-cUT+lsqV70jYBtf8FkUjm9TOKxQCoNQ4cVse47oKZLLtEbvJxbRTXupMlvndINBFgYhakHQCgUfkQuyVstvqhA==
+"@unocha/hpc-repo-tools@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/@unocha/hpc-repo-tools/-/hpc-repo-tools-7.0.0.tgz#6e39011802c714d08b2185271dacb960eef8e634"
+  integrity sha512-I/J8djCQscjRws7MP5B1z2cpEZVZXI+JdhSpNmMEpqHdnxfVgt2YQPjdr8cqqq4bKT3EAJBe3RzwRowSXDEBuw==
   dependencies:
     eslint-config-prettier "10.1.1"
     eslint-plugin-unicorn "58.0.0"


### PR DESCRIPTION
> [!IMPORTANT]  
> Needs https://github.com/UN-OCHA/hpc-repo-tools/pull/94 merged + released first. Also, #253 should be merged first, to update `@unocha/hpc-repo-tools` to `v6.4.0` first, before going to next major version.