### PR TITLE
Bring back old behavior in `getHidInfo()`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@unocha/hpc-api-core",
-  "version": "13.0.0",
+  "version": "13.0.1",
   "description": "Core libraries supporting HPC.Tools API Backend",
   "license": "Apache-2.0",
   "private": false,

--- a/src/auth/hid.ts
+++ b/src/auth/hid.ts
@@ -61,10 +61,7 @@ export const getHidInfo = async (
     if (!res.ok) {
       if (res.status === 401) {
         const r = await res.json();
-        if (!HID_MESSAGE.is(r)) {
-          throw new ForbiddenError('Invalid Token');
-        }
-        const message = r.message;
+        const message = HID_MESSAGE.is(r) ? r.message : 'Invalid Token';
         HID_CACHE.store(token, { type: 'forbidden', message });
         throw new ForbiddenError(message);
       } else {


### PR DESCRIPTION
In 878f9333ee7d9247c4b01cb874f5fd6be9af7811, part of `getHidInfo()` method was rewritten to validate the response JSON object against the io-ts codec. At that time, same default message was kept at `'Invalid Token'`, but that message wasn't added to `HID_CACHE`. Now, old behavior is brought back.