### PR TITLE
Return array instead of `Set` from `groupObjectsByProperty()`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@unocha/hpc-api-core",
-  "version": "13.0.1",
+  "version": "14.0.0",
   "description": "Core libraries supporting HPC.Tools API Backend",
   "license": "Apache-2.0",
   "private": false,

--- a/src/lib/data/organizations.ts
+++ b/src/lib/data/organizations.ts
@@ -41,9 +41,9 @@ export const getOrganizationsInfo = async (
     await database.category.find({
       where: {
         id: {
-          [database.Op.IN]: [...categoriesByOrganizationId.values()]
-            .flatMap((crSet) => [...crSet])
-            .map((cr) => cr.categoryID),
+          [database.Op.IN]: categoriesByOrganizationId
+            .values()
+            .flatMap((categories) => categories.map((cr) => cr.categoryID)),
         },
         group: { [database.Op.IN]: ['organizationType', 'organizationLevel'] },
       },

--- a/src/lib/data/projects.ts
+++ b/src/lib/data/projects.ts
@@ -153,7 +153,7 @@ export async function getOrganizationIDsForProjects<
   for (const [projectId, projectData] of projects) {
     const projectVersionId = projectData.projectVersion.id;
     const pvos = groupedPVOs.get(projectVersionId) ?? [];
-    const organizationIds = new Set([...pvos].map((o) => o.organizationId));
+    const organizationIds = new Set(pvos.map((o) => o.organizationId));
     result.set(projectId, organizationIds);
   }
 
@@ -192,7 +192,7 @@ export async function getGoverningEntityIDsForProjects<
     const projectVersionId = projectData.projectVersion.id;
     const pvges = groupedPVGEs.get(projectVersionId) ?? [];
     const governingEntityIds = new Set(
-      [...pvges].map((pvge) => pvge.governingEntityId)
+      pvges.map((pvge) => pvge.governingEntityId)
     );
     result.set(projectId, governingEntityIds);
   }
@@ -211,7 +211,7 @@ export const getConditionFieldsForProjects = async <
   database: Database;
   projects: Map<ProjectId, Data>;
 }): Promise<
-  Map<ProjectId, Set<InstanceOfModel<Database['projectVersionField']>>>
+  Map<ProjectId, Array<InstanceOfModel<Database['projectVersionField']>>>
 > => {
   const projectVersionPlanIds = [...projects.values()].map(
     (v) => v.projectVersionPlan.id
@@ -230,13 +230,13 @@ export const getConditionFieldsForProjects = async <
 
   const result = new Map<
     ProjectId,
-    Set<InstanceOfModel<Database['projectVersionField']>>
+    Array<InstanceOfModel<Database['projectVersionField']>>
   >();
 
   for (const [projectId, projectData] of projects) {
     const projectVersionPlanId = projectData.projectVersionPlan.id;
     const conditionFields = groupedConditionFields.get(projectVersionPlanId);
-    result.set(projectId, conditionFields ?? new Set());
+    result.set(projectId, conditionFields ?? []);
   }
 
   return result;
@@ -354,12 +354,12 @@ export const getProjectBudgetsByOrgAndCluster = async <
       continue;
     }
 
-    const segment = segments?.size === 1 ? [...segments][0] : null;
+    const segment = segments?.length === 1 ? segments[0] : null;
     if (!segment) {
       continue;
     }
 
-    const breakdowns = breakdownsBySegment.get(segment.id) ?? new Set();
+    const breakdowns = breakdownsBySegment.get(segment.id) ?? [];
 
     const projectResult: ProjectBudgetSegmentBreakdown[] = [];
 
@@ -377,7 +377,7 @@ export const getProjectBudgetsByOrgAndCluster = async <
       let governingEntity: GoverningEntityId | null = null;
       let organization: OrganizationId | null = null;
 
-      const entities = entitiesByBreakdown.get(b.id) ?? new Set();
+      const entities = entitiesByBreakdown.get(b.id) ?? [];
       for (const e of entities) {
         if (e.objectType === 'globalCluster') {
           globalCluster = createBrandedValue(e.objectId);
@@ -440,7 +440,7 @@ export const getProjectBudgetsByOrgAndCluster = async <
     // Ensure that the organization IDs match the projectVersionOrganization
     const budgetOrgIDs = new Set(projectResult.map((i) => i.organization));
     const prvOrgIDs = new Set(
-      [...(orgsByProjectVersion.get(p.projectVersion.id) ?? [])].map(
+      (orgsByProjectVersion.get(p.projectVersion.id) ?? []).map(
         (pvo) => pvo.organizationId
       )
     );

--- a/src/lib/data/projects.ts
+++ b/src/lib/data/projects.ts
@@ -47,24 +47,24 @@ export async function getAllProjectsForPlan({
       }),
     'projectVersionId'
   );
-  const pvps = [...pvpsByProjectVersionId.values()];
   const pvsById = await findAndOrganizeObjectsByUniqueProperty(
     database.projectVersion,
     (t) =>
       t.find({
         where: {
           id: {
-            [Op.IN]: new Set(pvps.map((pvp) => pvp.projectVersionId)),
+            [Op.IN]: new Set(
+              pvpsByProjectVersionId.values().map((pvp) => pvp.projectVersionId)
+            ),
           },
         },
       }),
     'id'
   );
-  const projectVersions = [...pvsById.values()];
   const projects = await database.project.find({
     where: {
       id: {
-        [Op.IN]: new Set(projectVersions.map((pv) => pv.projectId)),
+        [Op.IN]: new Set(pvsById.values().map((pv) => pv.projectId)),
       },
     },
   });
@@ -74,9 +74,11 @@ export async function getAllProjectsForPlan({
       t.find({
         where: {
           id: {
-            [Op.IN]: [
-              ...new Set(pvps.map((pvp) => pvp.workflowStatusOptionId)),
-            ],
+            [Op.IN]: new Set(
+              pvpsByProjectVersionId
+                .values()
+                .map((pvp) => pvp.workflowStatusOptionId)
+            ),
           },
         },
       }),
@@ -133,15 +135,11 @@ export async function getOrganizationIDsForProjects<
   database: Database;
   projects: Map<ProjectId, Data>;
 }): Promise<Map<ProjectId, Set<OrganizationId>>> {
-  const projectVersionIds = [...projects.values()].map(
-    (p) => p.projectVersion.id
-  );
-
   const groupedPVOs = groupObjectsByProperty(
     await database.projectVersionOrganization.find({
       where: {
         projectVersionId: {
-          [Op.IN]: projectVersionIds,
+          [Op.IN]: projects.values().map((p) => p.projectVersion.id),
         },
       },
     }),
@@ -171,15 +169,11 @@ export async function getGoverningEntityIDsForProjects<
   database: Database;
   projects: Map<ProjectId, Data>;
 }): Promise<Map<ProjectId, Set<GoverningEntityId>>> {
-  const projectVersionIds = [...projects.values()].map(
-    (p) => p.projectVersion.id
-  );
-
   const groupedPVGEs = groupObjectsByProperty(
     await database.projectVersionGoverningEntity.find({
       where: {
         projectVersionId: {
-          [Op.IN]: projectVersionIds,
+          [Op.IN]: projects.values().map((p) => p.projectVersion.id),
         },
       },
     }),
@@ -213,15 +207,11 @@ export const getConditionFieldsForProjects = async <
 }): Promise<
   Map<ProjectId, Array<InstanceOfModel<Database['projectVersionField']>>>
 > => {
-  const projectVersionPlanIds = [...projects.values()].map(
-    (v) => v.projectVersionPlan.id
-  );
-
   const groupedConditionFields = groupObjectsByProperty(
     await database.projectVersionField.find({
       where: {
         projectVersionPlanId: {
-          [Op.IN]: projectVersionPlanIds,
+          [Op.IN]: projects.values().map((v) => v.projectVersionPlan.id),
         },
       },
     }),

--- a/src/util/index.ts
+++ b/src/util/index.ts
@@ -100,8 +100,8 @@ export const annotatedMap = <K, V>(objectType: string): AnnotatedMap<K, V> => {
 export const groupObjectsByProperty = <I, P extends keyof I>(
   objects: Iterable<I>,
   property: P
-): Map<I[P], Set<I>> => {
-  return groupObjectsByValue(objects, (o) => o[property]);
+): Map<I[P], I[]> => {
+  return Map.groupBy(objects, (o) => o[property]);
 };
 
 /**

--- a/src/util/index.ts
+++ b/src/util/index.ts
@@ -106,26 +106,6 @@ export const groupObjectsByProperty = <I, P extends keyof I>(
 
 /**
  * Take a collection of objects,
- * and group them by values produced by the given function for each object
- */
-export const groupObjectsByValue = <I, V>(
-  objects: Iterable<I>,
-  getValue: (i: I) => V
-): Map<V, Set<I>> => {
-  const result = new Map<V, Set<I>>();
-  for (const obj of objects) {
-    const value = getValue(obj);
-    let group = result.get(value);
-    if (!group) {
-      result.set(value, (group = new Set()));
-    }
-    group.add(obj);
-  }
-  return result;
-};
-
-/**
- * Take a collection of objects,
  * and create a map of them, using a particular property as the key
  */
 export const organizeObjectsByUniqueProperty = <I, P extends keyof I>(


### PR DESCRIPTION
There is a coincidence that we've upgraded to Node.js 22, so we can now use [`Map.groupBy()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map/groupBy), which produces an array in `Map` values, rather than `Set` we were using. This newly available method isn't why I am making this change. The reason is that we've been using `Set` to no purpose. Using `Set` logically implies uniqueness of elements, but since this method is for grouping objects, they will be considered same only if:
> both are the same object (meaning both values reference the same object in memory)

I got this from definition of [`Object.is()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/is#description) because that is what `Set`s use for [comparing value equality](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set#value_equality). `Set` actually uses SameValueZero algorithm, bit it is functionally the same for objects as Same-value equality, which is using `Object.is()`.

This can be illustrated with an example:
```js
new Set([{ duplicate: true }, { duplicate: true }]);
// Gives Set(2) {{…}, {…}}
```
The two objects are considered as different, even though they are same by value. As said, uniqueness of objects is only if they use same reference:
```js
const obj = { duplicate: true };
new Set([obj, obj]);
// Gives Set(1) {{…}}
```
Therefore, to break the illusion of uniqueness that is logically associated with `Set`s, the grouping is changed to arrays. This enables using `Map.groupBy()` and not the other way around. Method `groupObjectsByValue()` is removed, because it was essentially a polyfill for `Map.groupBy()`.

Using `Set`s wasn't only logically deceiving, but it also meant that we cannot easily iterate the result values, since `Set` interface was mostly basic. That has changed now and we have iterator helpers in ES2025, but they are lazy and we still prefer arrays, due to them being more logically correct.