### PR TITLE
Remove `reviewers` from `dependabot.yml`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,5 @@
 # Documentation for all configuration options:
-# https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+# https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference
 
 version: 2
 updates:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,8 +11,6 @@ updates:
       timezone: 'Europe/Zurich'
     open-pull-requests-limit: 10
     versioning-strategy: increase
-    reviewers:
-      - '@UN-OCHA/hpc-js-reviewers'
     groups:
       jest:
         applies-to: version-updates
@@ -27,5 +25,3 @@ updates:
       interval: 'monthly'
       time: '11:00'
       timezone: 'Europe/Zurich'
-    reviewers:
-      - '@UN-OCHA/hpc-js-reviewers'


### PR DESCRIPTION
The Dependabot has warned us to do this with the following message:
> The `reviewers` field in the `dependabot.yml` file will be removed soon. Please use the code owners file to specify reviewers for Dependabot PRs. For more information, see [this blog post](https://github.blog/changelog/2025-04-29-dependabot-reviewers-configuration-option-being-replaced-by-code-owners).