### PR TITLE
Extend `JSON.stringify()` and `JSON.parse()`

### DIFF
--- a/src/util/index.ts
+++ b/src/util/index.ts
@@ -1,3 +1,4 @@
+import * as t from 'io-ts';
 import type { NonNegativeInteger } from './types';
 
 export const isDefined = <T>(v: T | null | undefined): v is T =>
@@ -345,3 +346,74 @@ export const splitIntoChunks = <T, N extends number>(
 
 export const areSetsEqual = <T>(a: Set<T>, b: Set<T>): boolean =>
   a.symmetricDifference(b).size === 0;
+
+const SERIALIZABLE = t.union([
+  t.type({
+    __serialized_type__: t.literal('Map'),
+    value: t.array(t.tuple([t.unknown, t.unknown])),
+  }),
+  t.type({
+    __serialized_type__: t.literal('Set'),
+    value: t.array(t.unknown),
+  }),
+]);
+type Serializable = t.TypeOf<typeof SERIALIZABLE>;
+
+const isSerializable = (value: unknown): value is Serializable =>
+  SERIALIZABLE.is(value);
+
+/**
+ * BEWARE: This method should be used in conjunction with `extendedJsonParse()`!
+ *
+ * Stringify a value, extending the standard `JSON.stringify()` behavior to
+ * serialize `Map`s and `Set`s.
+ *
+ * When serializing a `Map`, the value will be replaced with an object that
+ * contains a `'__serialized_type__'` property with value `'Map'`, and a `'value'`
+ * property with an array of tuples of the key-value pairs in the `Map`.
+ *
+ * When serializing a `Set`, the value will be replaced with an object that
+ * contains a `'__serialized_type__'` property with value `'Set'`, and a `'value'`
+ * property with an array of values in the `Set`.
+ */
+export const extendedJsonStringify = (value: unknown): string => {
+  const replacer = (_key: string, val: unknown): unknown => {
+    if (val instanceof Map) {
+      return {
+        __serialized_type__: 'Map',
+        value: [...val],
+      };
+    } else if (val instanceof Set) {
+      return {
+        __serialized_type__: 'Set',
+        value: [...val],
+      };
+    }
+
+    return val;
+  };
+
+  return JSON.stringify(value, replacer);
+};
+
+/**
+ * BEWARE: This method should be used in conjunction with `extendedJsonStringify()`!
+ *
+ * Parse a string, extending the standard `JSON.parse()`
+ * behavior to deserialize `Map`s and `Set`s.
+ */
+export const extendedJsonParse = (text: string): unknown => {
+  const reviver = (_key: string, val: unknown): unknown => {
+    if (isSerializable(val)) {
+      if (val.__serialized_type__ === 'Map') {
+        return new Map(val.value);
+      } else if (val.__serialized_type__ === 'Set') {
+        return new Set(val.value);
+      }
+    }
+
+    return val;
+  };
+
+  return JSON.parse(text, reviver);
+};

--- a/tests/utils/util.spec.ts
+++ b/tests/utils/util.spec.ts
@@ -1,4 +1,7 @@
 import {
+  areSetsEqual,
+  extendedJsonParse,
+  extendedJsonStringify,
   mapToObject,
   range,
   splitIntoChunks,
@@ -138,6 +141,200 @@ describe('Test utility functions', () => {
         ['a', 'b'],
         ['c', 'd'],
       ]);
+    });
+  });
+
+  describe('extendedJsonStringify', () => {
+    it('should serialize a Map', () => {
+      const input = new Map([
+        ['a', 1],
+        ['b', 2],
+      ]);
+
+      const json = extendedJsonStringify(input);
+      const parsed = JSON.parse(json);
+
+      expect(parsed).toEqual({
+        __serialized_type__: 'Map',
+        value: [
+          ['a', 1],
+          ['b', 2],
+        ],
+      });
+    });
+
+    it('should serialize a Set', () => {
+      const input = new Set([1, 2, 2, 3]);
+      const json = extendedJsonStringify(input);
+      const parsed = JSON.parse(json);
+
+      expect(parsed).toEqual({
+        __serialized_type__: 'Set',
+        value: [1, 2, 3],
+      });
+    });
+
+    it('should serialize a nested structure with Map and Set', () => {
+      const input = {
+        name: 'example',
+        data: new Map([['key', new Set([1, 2])]]),
+      };
+
+      const json = extendedJsonStringify(input);
+      const parsed = JSON.parse(json);
+
+      expect(parsed).toEqual({
+        name: 'example',
+        data: {
+          __serialized_type__: 'Map',
+          value: [
+            [
+              'key',
+              {
+                __serialized_type__: 'Set',
+                value: [1, 2],
+              },
+            ],
+          ],
+        },
+      });
+    });
+
+    it('should serialize a regular object without changes', () => {
+      const input = { key: 'value', num: 42 };
+      const json = extendedJsonStringify(input);
+      const parsed = JSON.parse(json);
+
+      expect(parsed).toEqual(input);
+    });
+  });
+
+  describe('extendedJsonParse', () => {
+    describe('extendedJsonParse with plain JSON.stringify()', () => {
+      it('should deserialize a serialized Map', () => {
+        const serialized = JSON.stringify({
+          __serialized_type__: 'Map',
+          value: [['x', 10]],
+        });
+
+        const result = extendedJsonParse(serialized);
+
+        expect(result).toBeInstanceOf(Map);
+        expect((result as Map<string, number>).get('x')).toBe(10);
+      });
+
+      it('should deserialize a serialized Set', () => {
+        const serialized = JSON.stringify({
+          __serialized_type__: 'Set',
+          value: [1, 2, 3],
+        });
+
+        const result = extendedJsonParse(serialized);
+
+        expect(result).toBeInstanceOf(Set);
+        expect([...(result as Set<number>)]).toEqual([1, 2, 3]);
+      });
+
+      it('should deserialize a nested structure with Map and Set', () => {
+        const input = {
+          name: 'nested',
+          data: {
+            __serialized_type__: 'Map',
+            value: [
+              [
+                'k',
+                {
+                  __serialized_type__: 'Set',
+                  value: [5, 6],
+                },
+              ],
+            ],
+          },
+        };
+
+        const serialized = JSON.stringify(input);
+        const result = extendedJsonParse(serialized) as any;
+
+        expect(result.name).toBe('nested');
+        expect(result.data).toBeInstanceOf(Map);
+
+        const nestedSet = result.data.get('k');
+        expect(nestedSet).toBeInstanceOf(Set);
+        expect([...nestedSet]).toEqual([5, 6]);
+      });
+
+      it('should parse a regular JSON string without changes', () => {
+        const input = { x: 100, y: false };
+        const json = JSON.stringify(input);
+        const result = extendedJsonParse(json);
+
+        expect(result).toEqual(input);
+      });
+    });
+
+    describe('extendedJsonParse with extendedJsonStringify', () => {
+      it('should correctly round-trip a Map', () => {
+        const input = new Map<string, string | number>([
+          ['username', 'alice'],
+          ['id', 42],
+        ]);
+
+        const json = extendedJsonStringify(input);
+        const result = extendedJsonParse(json);
+
+        expect(result).toBeInstanceOf(Map);
+        expect((result as Map<string, unknown>).get('username')).toBe('alice');
+        expect((result as Map<string, unknown>).get('id')).toBe(42);
+      });
+
+      it('should correctly round-trip a Set', () => {
+        const input = new Set(['read', 'write', 'delete']);
+
+        const json = extendedJsonStringify(input);
+        const result = extendedJsonParse(json) as Set<string>;
+
+        expect(result).toBeInstanceOf(Set);
+        expect(areSetsEqual(input, result)).toBe(true);
+      });
+
+      it('should correctly round-trip an object containing Map and Set', () => {
+        const input = {
+          roles: new Set(['admin', 'editor']),
+          metadata: new Map<string, string | number>([
+            ['createdBy', 'system'],
+            ['version', 3],
+          ]),
+        };
+
+        const json = extendedJsonStringify(input);
+        const result = extendedJsonParse(json);
+
+        expect(typeof result).toBe('object');
+        expect(result).not.toBeNull();
+
+        const typedResult = result as {
+          roles: Set<string>;
+          metadata: Map<string, unknown>;
+        };
+
+        expect(typedResult.roles).toBeInstanceOf(Set);
+        expect(typedResult.metadata).toBeInstanceOf(Map);
+        expect(areSetsEqual(typedResult.roles, input.roles)).toBe(true);
+        expect(typedResult.metadata.get('createdBy')).toBe('system');
+        expect(typedResult.metadata.get('version')).toBe(3);
+      });
+
+      it('should correctly round-trip a plain object without Map or Set', () => {
+        const input = {
+          status: 'active',
+          retries: 5,
+        };
+
+        const json = extendedJsonStringify(input);
+        const result = extendedJsonParse(json);
+
+        expect(result).toEqual(input);
+      });
     });
   });
 });

--- a/tests/utils/util.spec.ts
+++ b/tests/utils/util.spec.ts
@@ -144,6 +144,46 @@ describe('Test utility functions', () => {
     });
   });
 
+  describe('areSetsEqual', () => {
+    it('should return true for two empty sets', () => {
+      expect(areSetsEqual(new Set(), new Set())).toBe(true);
+    });
+
+    it('should return true for sets with same elements in different order', () => {
+      expect(areSetsEqual(new Set([1, 2, 3]), new Set([3, 2, 1]))).toBe(true);
+    });
+
+    it('should return false for sets with different elements', () => {
+      expect(areSetsEqual(new Set([1, 2]), new Set([2, 3]))).toBe(false);
+    });
+
+    it('should return false if sets have different sizes', () => {
+      expect(areSetsEqual(new Set([1]), new Set([1, 2]))).toBe(false);
+    });
+
+    it('should return false if only one set is empty', () => {
+      expect(areSetsEqual(new Set(), new Set([1]))).toBe(false);
+    });
+
+    it('should return true for sets with same string elements', () => {
+      expect(areSetsEqual(new Set(['a', 'b']), new Set(['b', 'a']))).toBe(true);
+    });
+
+    it('should return true for sets with same object references', () => {
+      const obj1 = { x: 1 };
+      const obj2 = { y: 2 };
+      const setA = new Set([obj1, obj2]);
+      const setB = new Set([obj2, obj1]);
+      expect(areSetsEqual(setA, setB)).toBe(true);
+    });
+
+    it('should return false for sets with different object references', () => {
+      const setA = new Set([{ x: 1 }]);
+      const setB = new Set([{ x: 1 }]);
+      expect(areSetsEqual(setA, setB)).toBe(false); // Different object identities
+    });
+  });
+
   describe('extendedJsonStringify', () => {
     it('should serialize a Map', () => {
       const input = new Map([


### PR DESCRIPTION
Methods `JSON.stringify()` and `JSON.parse()` are extended to support serialization/deserialization of `Map` and `Set` built-ins.

Also, method `areSetsEqual()` is covered in unit tests now. This should have been done in same work when this method was added, but since it was used to test extended `JSON.stringify()` and `JSON.parse()`, it is also covered with tests here.