### PR TITLE
Add io-ts codec to represent built-in `Map` type

### DIFF
--- a/src/util/types.ts
+++ b/src/util/types.ts
@@ -1,3 +1,6 @@
+import { isRight } from 'fp-ts/lib/Either';
+import * as t from 'io-ts';
+import { PathReporter } from 'io-ts/PathReporter';
 import type { FieldDefinition } from '../db/util/model-definition';
 
 /**
@@ -55,4 +58,53 @@ export const getTableColumns = <
   ];
 
   return columns;
+};
+
+/**
+ * Codec to represent built-in `Map` type.
+ *
+ * Be warned that `JSON.stringify()` and `JSON.parse()` don't support `Map` and this can
+ * lead to unexpected behavior if you use this codec in serialization/deserialization.
+ *
+ * ```ts
+ * // Will give you an empty object in string instead of serialized `Map`
+ * JSON.stringify(new Map([[1, 'value']])); // Produces '{}'
+ * ```
+ */
+export const map = <K, V>(
+  domain: t.Type<K>,
+  codomain: t.Type<V>,
+  name = `Map<${domain.name}, ${codomain.name}>`
+): t.Type<Map<K, V>> => {
+  return new t.Type(
+    name,
+    (u): u is Map<K, V> =>
+      u instanceof Map &&
+      [...u].every(([key, value]) => domain.is(key) && codomain.is(value)),
+    (u, c) => {
+      if (!(u instanceof Map)) {
+        return t.failure(u, c, 'Input is not a Map');
+      }
+
+      let validationResult;
+      let validationError: string | null = null;
+      for (const [key, value] of u) {
+        // Validate key
+        if (!isRight((validationResult = domain.validate(key, c)))) {
+          validationError = `Invalid type for key: '${key}'. Error: ${PathReporter.report(validationResult)}`;
+          break;
+        }
+        // Validate value
+        if (!isRight((validationResult = codomain.validate(value, c)))) {
+          validationError = `Invalid type for value at key: '${key}'. Error: ${PathReporter.report(validationResult)}`;
+          break;
+        }
+      }
+
+      return validationError !== null
+        ? t.failure(u, c, validationError)
+        : t.success(u as Map<K, V>);
+    },
+    t.identity
+  );
 };

--- a/tests/utils/types.spec.ts
+++ b/tests/utils/types.spec.ts
@@ -1,4 +1,6 @@
-import { getTableColumns } from '../../src/util/types';
+import { isRight } from 'fp-ts/Either';
+import * as t from 'io-ts';
+import { getTableColumns, map } from '../../src/util/types';
 import ContextProvider from '../testContext';
 
 const context = ContextProvider.Instance;
@@ -30,5 +32,92 @@ describe("Test 'getTableColumns' function", () => {
     expect(columns).toBeDefined();
     expect(columns).toBeInstanceOf(Array);
     expect(columns).toHaveLength(0);
+  });
+});
+
+describe('map codec', () => {
+  const numberToStringMap = map(t.number, t.string);
+
+  it('should decode a valid Map<number, string>', () => {
+    const input = new Map<number, string>([
+      [1, 'a'],
+      [2, 'b'],
+    ]);
+
+    const result = numberToStringMap.decode(input);
+    expect(isRight(result)).toBe(true);
+    if (isRight(result)) {
+      expect(result.right instanceof Map).toBe(true);
+      expect(result.right.get(1)).toBe('a');
+    }
+  });
+
+  it('should fail if a key is of the wrong type', () => {
+    const input = new Map<string, string>([['wrong-key', 'value']]);
+
+    const result = numberToStringMap.decode(input);
+    expect(isRight(result)).toBe(false);
+    if (!isRight(result)) {
+      expect(result.left[0].message).toBe(
+        `Invalid type for key: 'wrong-key'. Error: Invalid value "wrong-key" supplied to : Map<number, string>`
+      );
+    }
+  });
+
+  it('should fail if a value is of the wrong type', () => {
+    const input = new Map<number, unknown>([
+      [1, 'a'],
+      [2, 999], // Invalid value
+    ]);
+
+    const result = numberToStringMap.decode(input);
+    expect(isRight(result)).toBe(false);
+    if (!isRight(result)) {
+      expect(result.left[0].message).toBe(
+        "Invalid type for value at key: '2'. Error: Invalid value 999 supplied to : Map<number, string>"
+      );
+    }
+  });
+
+  it('should fail if input is not a Map', () => {
+    const input = { a: 1 };
+
+    const result = numberToStringMap.decode(input);
+    expect(isRight(result)).toBe(false);
+  });
+
+  it('should use the provided codec name in error messages', () => {
+    const CustomMap = map(t.string, t.boolean, 'CustomMap');
+    const input = new Map<unknown, unknown>([[123, true]]);
+
+    const result = CustomMap.decode(input);
+    expect(isRight(result)).toBe(false);
+    if (!isRight(result)) {
+      expect(
+        result.left[0].context.some((c) => c.type.name === 'CustomMap')
+      ).toBe(true);
+      expect(result.left[0].message).toBe(
+        "Invalid type for key: '123'. Error: Invalid value 123 supplied to : CustomMap"
+      );
+    }
+  });
+
+  it('should work as a type guard', () => {
+    expect(
+      numberToStringMap.is(
+        new Map([
+          [1, 'a'],
+          [2, 'b'],
+        ])
+      )
+    ).toBe(true);
+    expect(
+      numberToStringMap.is(
+        new Map([
+          [1, 1],
+          [2, 2],
+        ])
+      )
+    ).toBe(false);
   });
 });


### PR DESCRIPTION
Borrowed code from [here](https://github.com/gcanti/io-ts/issues/491#issuecomment-657436303) and modified slightly. Also made it throw an error if value is not a `Map`, because I think that is the correct behavior. Unit tests written with a help of LLM.