### PR TITLE
Add type-safe methods to convert `Map` to object and iterate it

### DIFF
--- a/src/util/index.ts
+++ b/src/util/index.ts
@@ -12,6 +12,46 @@ export const definedEntries = <K extends string, V>(o: {
 }): Array<[K, V]> =>
   [...(Object.entries(o) as Array<[K, V]>)].filter(([_k, v]) => isDefined(v));
 
+/**
+ * Strict version of `Object.entries()` that has a more useful key type,
+ * but doesn't do filtering like `definedEntries()`.
+ *
+ * If we have object like this:
+ *
+ * ```ts
+ * const object = {
+ *   planLocation: [{ id: 1, planId: 100 }],
+ *   planYear: [{ id: 1, planId: 200 }],
+ * };
+ * ```
+ *
+ * looping over it using built-in `Object.entries()` with
+ *
+ * ```ts
+ * for (const [key, value] of Object.entries(object)) { ... }
+ * ```
+ *
+ * will produce the type of `key` as generic `string` and type of `value` is
+ *
+ * ```ts
+ * {
+ *   id: number;
+ *   planId: number;
+ * }[] | {
+ *   id: number;
+ *   planId: number;
+ * }[]
+ * ```
+ *
+ * If we were to use loop over `objectEntries(object)`, with this
+ * method instead of built-in `Object.entries()`, we would get
+ * the type of `key` as `"planLocation" | "planYear"` and type of `value`
+ * stays the same, as it was already properly typed.
+ */
+export const objectEntries = <K extends PropertyKey, V>(obj: {
+  [P in K]: V;
+}): Array<[K, V]> => Object.entries(obj) as Array<[K, V]>;
+
 export const delay = (ms: number): Promise<unknown> =>
   new Promise((resolve) => setTimeout(resolve, ms));
 export type RecursivePartial<T> = T extends number

--- a/src/util/index.ts
+++ b/src/util/index.ts
@@ -219,6 +219,27 @@ export const mapObjectEntries = <K extends string | symbol, V1, V2>(
   ) as { [key in K]: V2 };
 };
 
+/**
+ * Typesafe method to convert `Map` to object, because converting
+ * using `Object.fromEntries()` uses generic `string` for keys
+ *
+ * @example
+ * type TableName = 'planLocation' | 'planYear';
+ * type TableRecord = { id: number; planId: number };
+ * const map = new Map<TableName, TableRecord[]>();
+ * const withObjectFromEntries = Object.fromEntries(map); // Typed as `{ [k: string]: TableRecord[]; }`
+ * const objectFromMap = mapToObject(map); // Typed as `{ planLocation: TableRecord[]; planYear: TableRecord[]; }`
+ */
+export const mapToObject = <K extends PropertyKey, V>(
+  map: Map<K, V>
+): { [P in K]: V } => {
+  const obj = {} as { [P in K]: V };
+  for (const [key, value] of map.entries()) {
+    obj[key] = value;
+  }
+  return obj;
+};
+
 export type MapValue<M extends Map<unknown, unknown>> =
   M extends Map<unknown, infer V> ? V : unknown;
 

--- a/tests/utils/util.spec.ts
+++ b/tests/utils/util.spec.ts
@@ -1,6 +1,63 @@
-import { range, splitIntoChunks, toCamelCase } from '../../src/util';
+import {
+  mapToObject,
+  range,
+  splitIntoChunks,
+  toCamelCase,
+} from '../../src/util';
 
 describe('Test utility functions', () => {
+  describe('mapToObject', () => {
+    it('converts a simple Map<string, number> to an object', () => {
+      const map = new Map<string, number>([
+        ['a', 1],
+        ['b', 2],
+      ]);
+      const obj = mapToObject(map);
+      expect(obj).toEqual({ a: 1, b: 2 });
+    });
+
+    it('converts a Map of union string keys to correctly typed object', () => {
+      type TableName = 'planLocation' | 'planYear';
+      type TableRecord = { id: number; planId: number };
+
+      const records: Record<TableName, TableRecord[]> = {
+        planLocation: [{ id: 1, planId: 100 }],
+        planYear: [{ id: 2, planId: 200 }],
+      };
+
+      const map = new Map<TableName, TableRecord[]>([
+        ['planLocation', records.planLocation],
+        ['planYear', records.planYear],
+      ]);
+
+      const obj = mapToObject(map);
+
+      expect(obj).toEqual(records);
+      // Type check: obj should be `{ planLocation: TableRecord[], planYear: TableRecord[] }`
+      obj satisfies Record<TableName, TableRecord[]>; // Should not produce a TypeScript error
+    });
+
+    it('returns an empty object when given an empty map', () => {
+      const map = new Map<string, number>();
+      const obj = mapToObject(map);
+      expect(obj).toEqual({});
+    });
+
+    it('preserves non-string keys like numbers and symbols', () => {
+      const sym = Symbol('key');
+      const map = new Map<PropertyKey, string>([
+        [1, 'one'],
+        ['two', '2'],
+        [sym, 'symbol'],
+      ]);
+
+      const obj = mapToObject(map);
+      expect(obj[1]).toBe('one');
+      expect(obj['two']).toBe('2');
+      expect(obj[sym]).toBe('symbol');
+    });
+  });
+
   describe('toCamelCase', () => {
     it('should convert string to camel case', () => {
       expect(toCamelCase('')).toBe('');

--- a/tests/utils/util.spec.ts
+++ b/tests/utils/util.spec.ts
@@ -1,19 +1,21 @@
 import { range, splitIntoChunks, toCamelCase } from '../../src/util';
 
 describe('Test utility functions', () => {
-  it('should convert string to camel case', () => {
-    expect(toCamelCase('')).toBe('');
-    expect(toCamelCase('Reached')).toBe('reached');
-    expect(toCamelCase('Cumulative reach')).toBe('cumulativeReach');
-    expect(toCamelCase('Double  space')).toBe('doubleSpace');
-    expect(toCamelCase('  leading space')).toBe('leadingSpace');
-    expect(toCamelCase('trailing space  ')).toBe('trailingSpace');
-    expect(toCamelCase('  both ends  ')).toBe('bothEnds');
-    expect(toCamelCase('with three words')).toBe('withThreeWords');
-    expect(toCamelCase('Mixed CASE')).toBe('mixedCase');
-    expect(toCamelCase('Another Test CASE')).toBe('anotherTestCase');
-    expect(toCamelCase('version 1.0')).toBe('version1.0');
-    expect(toCamelCase('2fast 2furious')).toBe('2fast2furious');
+  describe('toCamelCase', () => {
+    it('should convert string to camel case', () => {
+      expect(toCamelCase('')).toBe('');
+      expect(toCamelCase('Reached')).toBe('reached');
+      expect(toCamelCase('Cumulative reach')).toBe('cumulativeReach');
+      expect(toCamelCase('Double  space')).toBe('doubleSpace');
+      expect(toCamelCase('  leading space')).toBe('leadingSpace');
+      expect(toCamelCase('trailing space  ')).toBe('trailingSpace');
+      expect(toCamelCase('  both ends  ')).toBe('bothEnds');
+      expect(toCamelCase('with three words')).toBe('withThreeWords');
+      expect(toCamelCase('Mixed CASE')).toBe('mixedCase');
+      expect(toCamelCase('Another Test CASE')).toBe('anotherTestCase');
+      expect(toCamelCase('version 1.0')).toBe('version1.0');
+      expect(toCamelCase('2fast 2furious')).toBe('2fast2furious');
+    });
   });
 
   describe('range', () => {


### PR DESCRIPTION
I've added extensive docstrings with examples, which I usually don't do. So, I will not repeat myself here. The idea for adding these methods stemmed from desire to be able to convert `Map` to array and keep type safety of the keys, because `Object.fromEntries()` doesn't provide such type safety. Later, when such object (or any other) is iterated, the keys again need to be strongly typed, because `Object.entries()` is generic with `string` as key type (as both of them are actually).

**Edit**: After opening this PR, I have realized that we have `definedEntries()` method, which is very also a type-safe variant of `Object.entries()`, but it does a bit more (I mean the filtering, not unnecessary destructuring :) ). After learning this, I have moved my code to be in the same file, where the existence of both is more obvious.

There is also `mapObjectEntries()` in that file, but it does something else, even though it uses both `Object.fromEntries()` and `Object.entries()`, but it makes me wonder if `Object.fromEntries()` is meant to be used only to assemble back (processed results of) `Object.entries()` and if usage with other `Iterable` instances, like `Map` isn't the original idea, since their naming kinda indicates so.