### PR TITLE
Fix `type` column potential value in `expiredData` model

### DIFF
--- a/src/db/models/expiredData.ts
+++ b/src/db/models/expiredData.ts
@@ -3,7 +3,7 @@ import { DATE } from '../util/datatypes';
 import { defineRawModel } from '../util/raw-model';
 
 const EXPIRED_DATA_TYPE = {
-  solr: null,
+  flow: null,
 };
 
 const EXPIRED_OBJECT_TYPE = {


### PR DESCRIPTION
The [schema change](https://github.com/UN-OCHA/hpc_service/blob/f7093b1146b573807fbff3dc49ee7ec3c23d11a7/app/models/migrations/z.release3.12.07.v001.migration.ts#L9-L11) which introduced this table clearly indicates that `type` column can only have value `'flow'` and not `'solr'`.

Other column named `objectType` can be `'flow'` or `'project'`, so it was potentially a mistake in the enum in that schema change and `'solr'` was actually supposed to be a value, but since table isn't used for anything, I just changed model to make it possible to use this table when writing unit tests. If you think that changing the enum in the DB instead of changing the model would be better, I can do that too.