### PR TITLE
HPC-8748: Purge `categoryRef` after deleting project

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@unocha/hpc-api-core",
-  "version": "14.2.0",
+  "version": "14.3.0",
   "description": "Core libraries supporting HPC.Tools API Backend",
   "license": "Apache-2.0",
   "private": false,

--- a/src/db/deletion/project.ts
+++ b/src/db/deletion/project.ts
@@ -20,11 +20,14 @@ export const deleteProjectById = async (
     throw new NotFoundError(`No project with ID ${projectToDelete}`);
   }
 
+  if (project.latestVersionId === null) {
+    throw new PreconditionFailedError(
+      `Project with ID ${project.id} has no latest version ID`
+    );
+  }
+
   // Cannot delete already published project
-  if (
-    project.latestVersionId !== null &&
-    project.currentPublishedVersionId === project.latestVersionId
-  ) {
+  if (project.currentPublishedVersionId === project.latestVersionId) {
     throw new PreconditionFailedError(
       `Latest version of project with ID ${project.id} has already been published`
     );
@@ -160,8 +163,19 @@ export const deleteProjectById = async (
     });
 
     // Delete weak references
+
     await database.expiredData.destroy({
       where: { objectType: 'project', objectId: project.id },
+      trx,
+    });
+
+    // References to projectVersion in categoryRef aren't being
+    // used anymore, so, remove this if data ever gets cleaned up
+    await database.categoryRef.destroy({
+      where: {
+        objectType: 'projectVersion',
+        objectID: project.latestVersionId,
+      },
       trx,
     });
 

--- a/src/db/deletion/project.ts
+++ b/src/db/deletion/project.ts
@@ -63,6 +63,23 @@ export const deleteProjectById = async (
       trx,
     });
 
+    /**
+     * Related tables are purged through `ON DELETE CASCADE` foreign key constraints:
+     * - `projectVersionAttachment`
+     * - `projectLocations`
+     * - `budgetSegment`
+     *   - `budgetSegmentBreakdown`
+     *     - `budgetSegmentBreakdownEntity`
+     * - `projectVersionHistory`
+     * - `projectContact`
+     * - `projectVersionPlanEntity`
+     * - `projectVersionOrganization`
+     * - `projectVersionPlan`
+     *   - `projectVersionField`
+     *   - `projectVersionComment`
+     * - `projectGlobalClusters`
+     * - `projectVersionGoverningEntity`
+     */
     await database.projectVersion.destroy({
       where: { id: currentLatestVersion.id },
       trx,
@@ -118,6 +135,25 @@ export const deleteProjectById = async (
       trx,
     });
 
+    /**
+     * Related tables are purged through `ON DELETE CASCADE` foreign key constraints:
+     *
+     * - `projectVersion`
+     *   - `projectVersionAttachment`
+     *   - `projectLocations`
+     *   - `budgetSegment`
+     *     - `budgetSegmentBreakdown`
+     *       - `budgetSegmentBreakdownEntity`
+     *   - `projectVersionHistory`
+     *   - `projectContact`
+     *   - `projectVersionPlanEntity`
+     *   - `projectVersionOrganization`
+     *   - `projectVersionPlan`
+     *     - `projectVersionField`
+     *     - `projectVersionComment`
+     *   - `projectGlobalClusters`
+     *   - `projectVersionGoverningEntity`
+     */
     await database.project.destroy({
       where: { id: project.id },
       trx,


### PR DESCRIPTION
Deletion of project will trigger deletion of project version by cascading deletion constraint. So, after deletion of project version, its weak references need to be purged too, not only project's.