### PR TITLE
Optimize `areSetsEqual()`

### DIFF
--- a/src/util/index.ts
+++ b/src/util/index.ts
@@ -345,7 +345,7 @@ export const splitIntoChunks = <T, N extends number>(
   );
 
 export const areSetsEqual = <T>(a: Set<T>, b: Set<T>): boolean =>
-  a.symmetricDifference(b).size === 0;
+  a.size === b.size && a.isSubsetOf(b);
 
 const SERIALIZABLE = t.union([
   t.type({


### PR DESCRIPTION
PR opened based on [this discussion](https://github.com/UN-OCHA/hpc-api-core/pull/263#issuecomment-2879907360). There are several ways to check equality between two `Set`s using new `Set` methods:
1. `a.size === b.size && a.size === a.union(b).size`
2. `a.isSupersetOf(b) && a.isSubsetOf(b)`
3. `a.symmetricDifference(b).size === 0`
4. `a.size === b.size && a.isSubsetOf(b)`

LLM wrote me the script that I used to benchmark these 4 options and the ranking from fastest to slowest is 1-4-3-2, with 1 & 4 being really close in terms of performance and 2 & 3 are also really close between themselves, but more than twice slower than 1 & 4. Between 1 & 4, I prefer 4 because I see it as more readable.

<details>
<summary>Benchmarking script</summary>

```mjs
import { performance } from 'node:perf_hooks';

// Create arrays with duplicates
const size = 1_000_000;
const arrayWithDuplicates = Array.from({ length: size }, (_, i) => i % 900_000); // ~10% duplicates

const a = new Set(arrayWithDuplicates);
const b = new Set(arrayWithDuplicates); // Identical sets

// Define equality check variants
const variants = {
  '1. size === size && union size === size': () =>
    a.size === b.size && a.size === a.union(b).size,

  '2. isSupersetOf && isSubsetOf': () => a.isSupersetOf(b) && a.isSubsetOf(b),

  '3. symmetricDifference size === 0': () =>
    a.symmetricDifference(b).size === 0,

  '4. size === size && isSubsetOf': () => a.size === b.size && a.isSubsetOf(b),
};

// Benchmarking function
const benchmark = (fn, iterations = 100) => {
  const start = performance.now();
  for (let i = 0; i < iterations; i++) {
    fn();
  }
  return (performance.now() - start).toFixed(2);
};

// Run benchmarks
const iterations = 100;
console.log(
  `Benchmarking with sets of ~${a.size.toLocaleString()} unique elements, ${iterations} iterations each:\n`
);

for (const [label, fn] of Object.entries(variants)) {
  const time = benchmark(fn, iterations);
  console.log(`${label.padEnd(40)}: ${time} ms`);
}
```

</details>
