### PR TITLE
Improve organization deletion error message

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@unocha/hpc-api-core",
-  "version": "14.3.0",
+  "version": "14.4.0",
   "description": "Core libraries supporting HPC.Tools API Backend",
   "license": "Apache-2.0",
   "private": false,

--- a/src/db/deletion/organization.ts
+++ b/src/db/deletion/organization.ts
@@ -83,10 +83,13 @@ export const deleteOrganizationById = async (
           })
       )
     )
-  ).flat();
+  )
+    .flat()
+    .toSorted((firstFlow, secondFlow) => secondFlow.id - firstFlow.id);
 
   const projectVersions = await database.projectVersionOrganization.find({
     where: { organizationId: organization.id },
+    orderBy: { column: 'projectVersionId', order: 'desc' },
     trx,
   });
 

--- a/src/db/deletion/organization.ts
+++ b/src/db/deletion/organization.ts
@@ -55,17 +55,27 @@ export const deleteOrganizationById = async (
   });
 
   if (flows.length > 0 || projectVersions.length > 0) {
-    const flowIds = flows.map((flow) => flow.id).join(', ');
-    const projectVersionIds = projectVersions
-      .map((project) => project.projectVersionId)
-      .join(', ');
+    const formatIds = (ids: number[], limit: number = 10) => {
+      if (ids.length <= limit) {
+        return ids.join(', ');
+      }
+
+      const displayedIds = ids.slice(0, limit).join(', ');
+      const remainingCount = ids.length - limit;
+      return `${displayedIds} ... (+ ${remainingCount.toLocaleString()} more)`;
+    };
+
+    const flowIds = flows.map((flow) => flow.id);
+    const projectVersionIds = projectVersions.map(
+      (project) => project.projectVersionId
+    );
 
     let errorMessage = 'Cannot delete organization.';
     if (flows.length > 0) {
-      errorMessage += ` Associated flows: [${flowIds}].`;
+      errorMessage += ` Associated flows: [${formatIds(flowIds)}].`;
     }
     if (projectVersions.length > 0) {
-      errorMessage += ` Associated project versions: [${projectVersionIds}].`;
+      errorMessage += ` Associated project versions: [${formatIds(projectVersionIds)}].`;
     }
 
     throw new PreconditionFailedError(errorMessage);

--- a/src/db/deletion/organization.ts
+++ b/src/db/deletion/organization.ts
@@ -1,6 +1,7 @@
 import type { Knex } from 'knex';
 import type { Database } from '..';
-import { isDefined } from '../../util';
+import { splitIntoChunks } from '../../util';
+import { PG_MAX_QUERY_PARAMS } from '../../util/consts';
 import { NotFoundError, PreconditionFailedError } from '../../util/error';
 import type { FlowId } from '../models/flow';
 import type { OrganizationId } from '../models/organization';
@@ -72,17 +73,17 @@ export const deleteOrganizationById = async (
   // We double check in `flow` table, since flows can be soft deleted
   const flowVersions = (
     await Promise.all(
-      uniqueFlowVersions.map(({ id, versionID }) =>
-        database.flow.findOne({
-          where: {
-            id,
-            versionID,
-          },
-          trx,
-        })
+      splitIntoChunks(uniqueFlowVersions, PG_MAX_QUERY_PARAMS / 4).map(
+        (orConditions) =>
+          database.flow.find({
+            where: {
+              [database.Cond.OR]: orConditions,
+            },
+            trx,
+          })
       )
     )
-  ).filter(isDefined);
+  ).flat();
 
   const projectVersions = await database.projectVersionOrganization.find({
     where: { organizationId: organization.id },

--- a/src/db/deletion/organization.ts
+++ b/src/db/deletion/organization.ts
@@ -87,13 +87,30 @@ export const deleteOrganizationById = async (
     .flat()
     .toSorted((firstFlow, secondFlow) => secondFlow.id - firstFlow.id);
 
-  const projectVersions = await database.projectVersionOrganization.find({
-    where: { organizationId: organization.id },
-    orderBy: { column: 'projectVersionId', order: 'desc' },
+  const projectVersionOrganizations =
+    await database.projectVersionOrganization.find({
+      where: { organizationId: organization.id },
+      orderBy: { column: 'projectVersionId', order: 'desc' },
+      trx,
+    });
+  // Since we display only first 10 IDs, we want to get project IDs instead of
+  // project version IDs, thus we are being efficient and only getting first 10
+  // project IDs. The remaining project version IDs are just kept for the count
+  const first10ProjectVersions = projectVersionOrganizations.slice(0, 10);
+  const restProjectVersions = projectVersionOrganizations.slice(10);
+  const projectVersions = await database.projectVersion.find({
+    where: {
+      id: {
+        [database.Op.IN]: first10ProjectVersions.map(
+          (pvo) => pvo.projectVersionId
+        ),
+      },
+    },
+    orderBy: { column: 'projectId', order: 'desc' },
     trx,
   });
 
-  if (flowVersions.length > 0 || projectVersions.length > 0) {
+  if (flowVersions.length > 0 || projectVersionOrganizations.length > 0) {
     const formatIds = (ids: string[], limit: number = 10) => {
       if (ids.length <= limit) {
         return ids.join(', ');
@@ -105,16 +122,18 @@ export const deleteOrganizationById = async (
     };
 
     const flows = flowVersions.map((flow) => `${flow.id} v${flow.versionID}`);
-    const projectVersionIds = projectVersions.map((project) =>
-      project.projectVersionId.toString()
-    );
+    const projectIds = [
+      ...projectVersions.map((pv) => pv.projectId.toString()),
+      // As said above, for the remaining count, we use project version IDs
+      ...restProjectVersions.map((pvo) => pvo.projectVersionId.toString()),
+    ];
 
     let errorMessage = 'Cannot delete organization.';
-    if (flowVersions.length > 0) {
+    if (flows.length > 0) {
       errorMessage += ` Associated flow versions: [${formatIds(flows)}].`;
     }
-    if (projectVersions.length > 0) {
-      errorMessage += ` Associated project versions: [${formatIds(projectVersionIds)}].`;
+    if (projectIds.length > 0) {
+      errorMessage += ` Associated projects: [${formatIds(projectIds)}].`;
     }
 
     throw new PreconditionFailedError(errorMessage);

--- a/src/db/deletion/organization.ts
+++ b/src/db/deletion/organization.ts
@@ -2,7 +2,45 @@ import type { Knex } from 'knex';
 import type { Database } from '..';
 import { isDefined } from '../../util';
 import { NotFoundError, PreconditionFailedError } from '../../util/error';
+import type { FlowId } from '../models/flow';
 import type { OrganizationId } from '../models/organization';
+
+/**
+ * Since organization can appear on both source and destination side of same
+ * flow, we only are interested in flows where it appears on any side
+ */
+const getUniqueFlowVersions = async (
+  organizationId: OrganizationId,
+  database: Database,
+  trx: Knex.Transaction
+) => {
+  const flowObjects = await database.flowObject.find({
+    where: {
+      objectType: {
+        [database.Op.IN]: ['organization', 'anonymizedOrganization'],
+      },
+      objectID: organizationId,
+    },
+    trx,
+  });
+
+  type Key = `${FlowId}-v${number}`;
+  const seen = new Set<Key>();
+
+  return flowObjects
+    .map((fo) => ({
+      id: fo.flowID,
+      versionID: fo.versionID,
+    }))
+    .filter((flow) => {
+      const key: Key = `${flow.id}-v${flow.versionID}`;
+      if (seen.has(key)) {
+        return false;
+      }
+      seen.add(key);
+      return true;
+    });
+};
 
 /**
  * Organizations are soft deleted in the database. This method gives
@@ -26,22 +64,19 @@ export const deleteOrganizationById = async (
     );
   }
 
-  const flowObjects = await database.flowObject.find({
-    where: {
-      objectType: {
-        [database.Op.IN]: ['organization', 'anonymizedOrganization'],
-      },
-      objectID: organization.id,
-    },
-    trx,
-  });
-  const flows = (
+  const uniqueFlowVersions = await getUniqueFlowVersions(
+    organization.id,
+    database,
+    trx
+  );
+  // We double check in `flow` table, since flows can be soft deleted
+  const flowVersions = (
     await Promise.all(
-      flowObjects.map((fo) =>
+      uniqueFlowVersions.map(({ id, versionID }) =>
         database.flow.findOne({
           where: {
-            id: fo.flowID,
-            versionID: fo.versionID,
+            id,
+            versionID,
           },
           trx,
         })
@@ -54,8 +89,8 @@ export const deleteOrganizationById = async (
     trx,
   });
 
-  if (flows.length > 0 || projectVersions.length > 0) {
-    const formatIds = (ids: number[], limit: number = 10) => {
+  if (flowVersions.length > 0 || projectVersions.length > 0) {
+    const formatIds = (ids: string[], limit: number = 10) => {
       if (ids.length <= limit) {
         return ids.join(', ');
       }
@@ -65,14 +100,14 @@ export const deleteOrganizationById = async (
       return `${displayedIds} ... (+ ${remainingCount.toLocaleString()} more)`;
     };
 
-    const flowIds = flows.map((flow) => flow.id);
-    const projectVersionIds = projectVersions.map(
-      (project) => project.projectVersionId
+    const flows = flowVersions.map((flow) => `${flow.id} v${flow.versionID}`);
+    const projectVersionIds = projectVersions.map((project) =>
+      project.projectVersionId.toString()
     );
 
     let errorMessage = 'Cannot delete organization.';
-    if (flows.length > 0) {
-      errorMessage += ` Associated flows: [${formatIds(flowIds)}].`;
+    if (flowVersions.length > 0) {
+      errorMessage += ` Associated flow versions: [${formatIds(flows)}].`;
     }
     if (projectVersions.length > 0) {
       errorMessage += ` Associated project versions: [${formatIds(projectVersionIds)}].`;


### PR DESCRIPTION
The original intent was to truncate number of IDs shown in error message, because some organizations have tens of thousands of associated flows/projects, so the message gets ridiculously long. The slowness was observed in those cases, so I tried to optimize, by making fewer queries, since we were fetching flows using `findOne()`, which is too many queries when organization has tens of thousands of flows.

Antonio also asked to display project IDs instead of project version IDs, so I've done that as well. In that case, I was being optimal, by only fetching 10 that we'll display, but in case of fetching flows, I could not have done that, since they can be soft deleted, so querying `flow` table filters those out.

If you want to see the organizations with lots of flow connections, use this query:
```sql
SELECT fo."objectID", COUNT(*)
FROM "flowObject" fo
GROUP BY fo."objectID", fo."objectType"
HAVING (fo."objectType" = 'organization' OR fo."objectType" = 'anonymizedOrganization')
ORDER BY COUNT(*) DESC;
```

If you want to check how many unique flow versions there are (because above doesn't filter out deleted flows and situations where organization is on both source and destination side of same flow), then use this query (e.g. for organization ID 2915):
```sql
SELECT DISTINCT fo."flowID", fo."versionID"
FROM "flowObject" fo
JOIN flow f ON
  fo."flowID" = f.id AND fo."versionID" = f."versionID"
WHERE
  fo."objectID" = 2915 -- CHANGE THIS
  AND (
    fo."objectType" = 'organization' OR 
    fo."objectType" = 'anonymizedOrganization'
  )
  AND f."deletedAt" IS NULL
ORDER BY
  fo."flowID" DESC,
  fo."versionID" ASC;
```