### PR TITLE
Add all-uppercase "URL" as possible report file type

### DIFF
--- a/src/db/models/reportFile.ts
+++ b/src/db/models/reportFile.ts
@@ -15,6 +15,7 @@ export type ReportFileId = Brand<
 export const REPORT_FILE_TYPE = t.keyof({
   file: null,
   url: null,
+  URL: null,
 });
 
 export const REPORT_FILE_ID = brandedType<number, ReportFileId>(t.number);


### PR DESCRIPTION
In the database, both "url" (all-lowercase) and "URL" (all-uppercase) are regularly used in this column