### PR TITLE
Check existing email for first HID login too

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@unocha/hpc-api-core",
-  "version": "15.0.0",
+  "version": "15.0.1",
   "description": "Core libraries supporting HPC.Tools API Backend",
   "license": "Apache-2.0",
   "private": false,

--- a/src/auth/index.ts
+++ b/src/auth/index.ts
@@ -145,19 +145,18 @@ export const getLoggedInParticipant = async (
   });
 
   if (!participant) {
-    if (isEntraIDToken) {
-      // Check if there's a participant with this email
-      // address already, presumably created via HID
-      participant = await models.participant.findOne({
-        where: { email },
-      });
+    // Check if there's a participant with this email address already
+    participant = await models.participant.findOne({
+      where: { email },
+    });
 
-      if (participant) {
-        await models.participant.update({
-          values: { entraId: sub },
-          where: { id: participant.id },
-        });
-      }
+    if (participant) {
+      const otherSubProperty = isEntraIDToken ? 'hidSub' : 'entraId';
+
+      await models.participant.update({
+        values: { [otherSubProperty]: sub },
+        where: { id: participant.id },
+      });
     }
 
     // Create a new participant for this HID/Entra ID account


### PR DESCRIPTION
The existing code was written based on assumption that users switching to Entra ID already used HID before, so if the same email was used for HID that is now used for Entra ID, the same record in `participant` table would be kept.

But, that assumption is not necessarily true. While most users would have used HID before switching to Entra ID, it doesn't have to mean that they used same email address for both.

The fix wants to improve the situation if users first log into our system with Entra ID, then create HID with that same email address, regardless if they already have HID accounts with other email addresses.