### PR TITLE
🐛 Pick correct sub property

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@unocha/hpc-api-core",
-  "version": "15.1.0",
+  "version": "15.1.1",
   "description": "Core libraries supporting HPC.Tools API Backend",
   "license": "Apache-2.0",
   "private": false,

--- a/src/auth/index.ts
+++ b/src/auth/index.ts
@@ -151,10 +151,8 @@ export const getLoggedInParticipant = async (
     });
 
     if (participant) {
-      const otherSubProperty = isEntraIDToken ? 'hidSub' : 'entraId';
-
       await models.participant.update({
-        values: { [otherSubProperty]: sub },
+        values: { [subProperty]: sub },
         where: { id: participant.id },
       });
     }


### PR DESCRIPTION
This fixes a bug introduced in #316.

When user logs in for the first time with Entra ID, while previously have used HID, we should find user with that email and update `entraId` property.

Likewise, when they log in for the first time with HID, while previously have used Entra ID, we should update `hidSub` property.