### PR TITLE
chore: Permissions for new OIDC based trusted publishing.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,5 +19,3 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
       - run: npm install
       - run: npm publish
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,13 @@
 name: Node.js Package
+
 on:
   release:
     types: [created]
+
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
The rest of this are settings on the package on npmjs.org

Once this is merged and working, the package publishing settings can be modified to `Require two-factor authentication and disallow tokens (recommended)`

Refs: OPS-11824